### PR TITLE
Sites Update Command -- Issue 35

### DIFF
--- a/src/lib/sites/types.ts
+++ b/src/lib/sites/types.ts
@@ -93,29 +93,37 @@ export interface SwitchTemplatePayload extends SiteNamedPayload {
   template_id: string | number,
 }
 
-export interface UpdateSitePayload {
-  site_name: string,
-  site_domain?: string,
-  default_domain_prefix?: string,
-  external_uid?: string,
-  lang?: string,
-  site_alternate_domains?: {
+type FirstPartialUpdateSitePayload = {
+  site_name: string
+}
+
+type SecondPartialUpdateSitePayload = {
+  site_domain: string,
+  default_domain_prefix: string,
+  external_uid: string,
+  lang: string,
+  site_alternate_domains: {
     domains?: Array<string>,
     is_redirect?: boolean
   },
-  force_https?: boolean,
-  site_seo?: {
+  force_https: boolean,
+  site_seo: {
     og_image?: string,
     title?: string,
     description?: string
   },
-  schemas?: {
+  schemas: {
     local_business?: {
       enabled?: boolean
     }
   },
-  fav_icon?: string,
+  fav_icon: string,
 }
+
+type AtLeastOne<T, U = {[K in keyof T]: Pick<T, K> }> = Partial<T> & U[keyof U]
+
+export type UpdateSitePayload = FirstPartialUpdateSitePayload
+& AtLeastOne<SecondPartialUpdateSitePayload>
 
 export type GetSiteByNamePayload = {
   site_name: string,

--- a/tests/site.tests.ts
+++ b/tests/site.tests.ts
@@ -42,7 +42,6 @@ describe('Site tests', () => {
         scope.get(`${api_path}${site_name}`).reply(200, get_response)
         duda.sites.get({ site_name:site_name })
     })
-    // Doesn't require passing body params in Partner-API, at least one body param input required to use command (500)
     it('can update a site', () => {
         scope.post(`${api_path}update/${site_name}`, (body) => {
             expect(body).to.eql({ external_uid:external_uid })


### PR DESCRIPTION
- Redefined UpdateSitePayload in types.ts to properly require at least one body param in order to execute the command
- Removed comment in tests file to reflect this change (verified)