### PR TITLE
Fixes getSSO call

### DIFF
--- a/src/lib/accounts/Authentication.ts
+++ b/src/lib/accounts/Authentication.ts
@@ -11,10 +11,14 @@ class Authentication extends Resource {
     defaults: {
       host: 'api.duda.co',
     },
-    bodyParams: {
+    queryParams: {
       site_name: {
         type: 'string',
-        required: true,
+        required: false,
+      },
+      target: {
+        type: 'string',
+        required: false,
       },
     },
   });

--- a/src/lib/accounts/types.ts
+++ b/src/lib/accounts/types.ts
@@ -92,7 +92,7 @@ export interface GrantSiteAccessPayload {
   permissions: Array<Permissions>;
 }
 
-export type SSOLinkTargets = 'STATS' | 'EDITOR' | 'RESET_SITE';
+export type SSOLinkTargets = 'STATS' | 'EDITOR' | 'RESET_SITE' | 'SWITCH_TEMPLATE' | 'RESET_BASIC';
 
 export type GrantSiteAccessResponse = void;
 export type RemoveSiteAccessResponse = void;
@@ -105,7 +105,7 @@ export interface RemoveSiteAccessPayload {
 export interface GetSSOLinkPayload {
   account_name: string;
   site_name?: string;
-  target: SSOLinkTargets;
+  target?: SSOLinkTargets;
 }
 
 export interface GetSSOLinkResponse {

--- a/tests/account.tests.ts
+++ b/tests/account.tests.ts
@@ -24,10 +24,10 @@ describe('Account tests', () => {
     }
   ]
   const url = 'test_url.com'
-  // Uncomment in next major release
-  // const sso_url = {
-  //   url: url
-  // }
+  const sso_url = {
+    url: url
+  }
+
   const rest_url = {
     reset_url: url
   }
@@ -120,16 +120,16 @@ describe('Account tests', () => {
     })
   })
   describe('authentication', () => {
-    // Uncomment in next major release
-    // it('can grant single sign-on site access for an account by name', () => {
-    //   scope.get('/api/accounts/sso/test_account/link?site_name=test_site&target=STATS').reply(200, sso_url)
+    it('can grant single sign-on access for an account by name', () => {
+      scope.get('/api/accounts/sso/test_account/link?site_name=test_site&target=STATS').reply(200, sso_url)
 
-    //   return duda.accounts.authentication.getSSOLink({
-    //     account_name: 'test_account',
-    //     site_name: 'test_site',
-    //     target: 'STATS'
-    //   }).then(res => expect(res).to.eql(sso_url))
-    // })
+      return duda.accounts.authentication.getSSOLink({
+        account_name: 'test_account',
+        site_name: 'test_site',
+        target: 'STATS'
+      }).then(res => expect(res).to.eql(sso_url))
+    })
+
     it('can reset a password for an account by name', () => {
       scope.post('/api/accounts/reset-password/test_account').reply(200, rest_url)
       return duda.accounts.authentication.getResetPasswordLink({ account_name:'test_account' })


### PR DESCRIPTION
* puts site_name and target params on query string instead of body
* updates target type to include all values
* uncomments SSO test

closes #6