### PR TITLE
Fixes payloads for duplicate page v2 endpoint

### DIFF
--- a/src/lib/pages/types.ts
+++ b/src/lib/pages/types.ts
@@ -9,8 +9,8 @@ export namespace V1 {
     }
   }
 
-  export type UpdatePageResponse = void;
-  export type DuplicatePageResponse = void;
+  export type UpdatePageResponse = Page;
+  export type DuplicatePageResponse = Page;
   export type DeletePageResponse = void;
   export type GetPageResponse = Page;
   export type ListPagesResponse = Array<Page>;
@@ -49,14 +49,17 @@ export namespace V1 {
 }
 
 export namespace V2 {
+  export interface Seo {
+    title?: string,
+    description?: string,
+    no_index?: boolean,
+    og_image?: string
+  }
+
   export interface Page {
     title?: string,
     path?: string,
-    seo?: {
-      title?: string,
-      description?: string,
-      no_index?: boolean
-    },
+    seo?: Seo
     header_html?: string,
   }
 
@@ -75,23 +78,14 @@ export namespace V2 {
     site_name: string,
   }
 
-  export interface UpdatePagePayload {
+  export interface UpdatePagePayload extends Page {
     site_name: string,
     page_uuid: string,
-    title?: string,
-    path?: string,
-    seo?: {
-      title?: string,
-      description?: string,
-      no_index?: boolean,
-    },
-    header_html?: string,
   }
 
-  export interface DuplicatePagePayload {
+  export interface DuplicatePagePayload extends Page {
     site_name: string,
     page_uuid: string,
-    title: string,
   }
 
   export interface DeletePagePayload {

--- a/src/lib/pages/v2.ts
+++ b/src/lib/pages/v2.ts
@@ -57,6 +57,18 @@ class Pages extends Resource {
         type: 'string',
         required: false,
       },
+      path: {
+        type: 'string',
+        required: false,
+      },
+      seo: {
+        type: 'object',
+        required: false,
+      },
+      header_html: {
+        type: 'string',
+        required: false,
+      },
     },
   });
 

--- a/tests/page.tests.ts
+++ b/tests/page.tests.ts
@@ -6,28 +6,27 @@ describe('Page tests', () => {
     let duda: Duda;
     let scope: nock.Scope;
     const api_path = '/api/sites/multiscreen/';
+    const api_segment = '/pages';
     const site_name = 'test_site';
-
-    const page = {
-        uuid: "abc123",
-        title: "My Title",
-        path: "/test",
-        header_html: "<b>Some HTML</b>"
-    };
 
     const seo = {
         title: "My SEO Title",
         description: "SEO description of the page",
-        no_index: false
+        no_index: false,
+        og_image: "https://example.org/path/to/image.png"
     };
 
-    const response = {
-        result: [
-            page
-        ]
+    const page = {
+        title: "My Title",
+        path: "/test",
+        seo,
+        header_html: "<b>Some HTML</b>"
     };
 
-    const { uuid: page_uuid, title, path, header_html } = page;
+    const page_uuid = '123abc';
+
+    const response = { ...page, uuid: page_uuid };
+    const list = { results: [response] };
 
     before(() => {
         duda = new Duda({
@@ -38,39 +37,43 @@ describe('Page tests', () => {
 
         scope = nock('https://api.duda.co')
     })
+    
     it('can get all pages for a site name', () => {
-        scope.get(`${api_path}${site_name}/pages`).reply(200, response)
+        scope.get(`${api_path}${site_name}${api_segment}`).reply(200, list)
         duda.pages.v2.list({ site_name })
     })
+
     it('can get a page by name', () => {
-        scope.get(`${api_path}${site_name}/pages/${page_uuid}`).reply(200, page)
+        scope.get(`${api_path}${site_name}${api_segment}/${page_uuid}`).reply(200, response)
         duda.pages.v2.get({ site_name, page_uuid })
     })
 
     it('can update a page by uuid', () => {
-        scope.put(`${api_path}${site_name}/pages/${page_uuid}`, (body) => {
-            expect(body).to.eql({ title, path, header_html, seo: { ...seo } })
+        scope.put(`${api_path}${site_name}${api_segment}/${page_uuid}`, (body) => {
+            expect(body).to.eql(page)
             return body
-        }).reply(204)
+        }).reply(200, response)
         duda.pages.v2.update({
+            ...page,
             site_name,
             page_uuid,
-            title,
-            path,
-            seo,
-            header_html
         })
     })
 
     it('can duplicate a page by name', () => {
-        scope.post(`${api_path}${site_name}/pages/${page_uuid}/duplicate`, (body) => {
-            expect(body).to.eql({ title: title })
+        scope.post(`${api_path}${site_name}${api_segment}/${page_uuid}/duplicate`, (body) => {
+            expect(body).to.eql(page)
             return body
-        }).reply(204)
-        duda.pages.v2.duplicate({ site_name, page_uuid, title: title })
+        }).reply(200, response)
+        duda.pages.v2.duplicate({
+          ...page,
+          site_name,
+          page_uuid,
+        })
     })
+
     it('can delete a page by name', () => {
-        scope.delete(`${api_path}${site_name}/pages/${page_uuid}`).reply(204)
+        scope.delete(`${api_path}${site_name}${api_segment}/${page_uuid}`).reply(204)
         duda.pages.v2.delete({ site_name, page_uuid })
     })
 })


### PR DESCRIPTION
* Allows full SEO object
* Allows path parameter
* Allows header_html
* Updates types to correct responses for update and duplicate endpoints
* Updates tests to pass and check for new body params
* Updates tests to correct responses for clarity

closes #25
closes #26