### PR TITLE
Appstore SiteWideHTML Endpoints

### DIFF
--- a/src/lib/apps/swh/SWH.ts
+++ b/src/lib/apps/swh/SWH.ts
@@ -19,7 +19,7 @@ class AppsSWH extends SubResource {
 
   get = APIEndpoint<TokenRequest<Types.GetSWHPayload>, Types.GetSWHResponse>({
     method: 'get',
-    path: '/site/{site_name}/sitewidehtml/{swh_uuid}',
+    path: '/site/{site_name}/sitewidehtml/{uuid}',
     defaults: {
       host: 'api.duda.co',
     },
@@ -30,7 +30,7 @@ class AppsSWH extends SubResource {
     },
   });
 
-  add = APIEndpoint<TokenRequest<Types.CreateSWHPayload>, Types.CreateSWHResponse>({
+  create = APIEndpoint<TokenRequest<Types.CreateSWHPayload>, Types.CreateSWHResponse>({
     method: 'post',
     path: '/site/{site_name}/sitewidehtml',
     defaults: {
@@ -45,7 +45,7 @@ class AppsSWH extends SubResource {
 
   update = APIEndpoint<TokenRequest<Types.UpdateSWHPayload>, Types.UpdateSWHResponse>({
     method: 'put',
-    path: '/site/{site_name}/sitewidehtml/{swh_uuid}',
+    path: '/site/{site_name}/sitewidehtml/{uuid}',
     defaults: {
       host: 'api.duda.co',
     },
@@ -58,7 +58,7 @@ class AppsSWH extends SubResource {
 
   delete = APIEndpoint<TokenRequest<Types.DeleteSWHPayload>, Types.DeleteSWHResponse>({
     method: 'delete',
-    path: '/site/{site_name}/sitewidehtml/{swh_uuid}',
+    path: '/site/{site_name}/sitewidehtml/{uuid}',
     defaults: {
       host: 'api.duda.co',
     },

--- a/src/lib/apps/swh/types.ts
+++ b/src/lib/apps/swh/types.ts
@@ -1,10 +1,11 @@
 export interface SWH {
-  location: 'BODY' | 'HEAD' | 'CONTENT_END';
+  location: 'BODY' | 'HEAD' | 'CONTENT_END' | 'BEFORE_SCRIPTS';
   markup: string;
   uuid: string;
 }
 
 export interface ListSWHPayload {
+  site_name: string;
 }
 
 export interface ListSWHResponse {
@@ -19,21 +20,28 @@ export interface GetSWHPayload {
 export interface GetSWHResponse extends SWH {
 }
 
-export interface CreateSWHPayload extends SWH {
+export interface CreateSWHPayload {
+  site_name: string;
+  location?: 'BODY' | 'HEAD' | 'CONTENT_END' | 'BEFORE_SCRIPTS';
+  markup?: string;
 }
 
 export interface CreateSWHResponse extends SWH {
 }
 
 export interface UpdateSWHPayload {
-  markup: string;
+  site_name: string;
+  uuid: string;
+  location?: 'BODY' | 'HEAD' | 'CONTENT_END' | 'BEFORE_SCRIPTS';
+  markup?: string;
 }
 
 export interface UpdateSWHResponse extends SWH {
 }
 
 export interface DeleteSWHPayload {
-  markup: string;
+  site_name: string;
+  uuid: string;
 }
 
 export type DeleteSWHResponse = void;

--- a/tests/app/swh.tests.ts
+++ b/tests/app/swh.tests.ts
@@ -1,0 +1,78 @@
+import nock from "nock"
+import { expect } from "chai"
+import { Duda } from "../../src/index"
+
+describe('App store site wide html tests', () => {
+  const base_path = '/api/integrationhub/application' 
+  const site_name = 'test'
+  const user = 'testuser'
+  const pass = 'testpass'
+  const token = '123456'
+
+  const uuid = 'test_uuid'
+  const location = 'BODY'
+  const markup = 'markup'
+
+  const swh = {
+    location: location,
+    markup: markup,
+    uuid: uuid
+  }
+
+  const swh_list_response = [swh]
+
+  let duda: Duda;
+  let scope: nock.Scope;
+
+  before(() => {
+    duda = new Duda({
+      user,
+      pass,
+      env: Duda.Envs.direct,
+    })
+
+    scope = nock('https://api.duda.co', {
+      reqheaders: {
+        'x-duda-access-token': `Bearer ${token}`
+      }
+    })
+  })
+
+  it('can list all site wide html', async () => {
+    scope.get(`${base_path}/site/${site_name}/sitewidehtml/list`).reply(200, swh_list_response)
+    return await duda.appstore.sitewidehtml.list({
+      site_name: site_name,
+      token
+    }).then(res => expect(res).to.eql(swh_list_response))
+  })
+
+  it('can create a site wide html', async () => {
+    scope.post(`${base_path}/site/${site_name}/sitewidehtml`, (body) => {
+      expect(body).to.eql({ location: location, markup: markup })
+      return body
+    }).reply(200, swh)
+
+    return await duda.appstore.sitewidehtml.create({ site_name, location, markup, token })
+  })
+
+  it('can get a specific site wide html', async () => {
+    scope.get(`${base_path}/site/${site_name}/sitewidehtml/${uuid}`).reply(200, swh)
+
+    return await duda.appstore.sitewidehtml.get({ site_name, uuid, token })
+      .then(res => expect(res).to.eql({ ...swh }))
+  })
+
+  it('can update a specific site wide html', async () => {
+    scope.put(`${base_path}/site/${site_name}/sitewidehtml/${uuid}`, (body) => {
+      expect(body).to.eql({ location, markup })
+      return body
+    }).reply(200, swh)
+
+    return await duda.appstore.sitewidehtml.update({ site_name, uuid, token, location, markup})
+  })
+
+  it('can delete a specific site wide html', async () => {
+    scope.delete(`${base_path}/site/${site_name}/sitewidehtml/${uuid}`).reply(204)
+    return await duda.appstore.sitewidehtml.delete({ site_name, uuid, token })
+  })
+})


### PR DESCRIPTION
- Cleaned up Appstore SiteWideHTML Endpoints
- Fixed payload and response bodies in types.ts file
- Created tests in swh.tests.ts file