### PR TITLE
Ecomm Order Refunds

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,7 +599,43 @@ function validateSSO(req: YourRequestObject): boolean {
 `GET https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}`
 
   ```typescript
-  duda.ecomm.carts.get({ site_name: site_name, order_id: order_id });
+  duda.ecomm.orders.get({ site_name: site_name, order_id: order_id });
+  ```
+
+## Update Order
+
+[Update Order Reference](https://developer.duda.co/reference/update-order)
+
+### Request
+
+`PATCH https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}`
+
+  ```typescript
+  duda.ecomm.orders.update({ site_name: site_name, order_id: order_id });
+  ```
+
+## List Refunds
+
+[List Refunds Reference](https://developer.duda.co/reference/list-refunds)
+
+### Request
+
+`GET https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/refunds`
+
+  ```typescript
+  duda.ecomm.orders.listRefunds({ site_name: site_name, order_id: order_id });
+  ```
+
+## Get Refund
+
+[Get Refund Reference](https://developer.duda.co/reference/get-refund)
+
+### Request
+
+`GET https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/refunds/{refund_id}`
+
+  ```typescript
+  duda.ecomm.orders.getRefund({ site_name: site_name, order_id: order_id, refund_id: refund_id });
   ```
 
 # eComm Payment Gateways

--- a/src/lib/ecomm/Orders.ts
+++ b/src/lib/ecomm/Orders.ts
@@ -36,6 +36,48 @@ class Orders extends Resource {
       host: 'api.duda.co',
     },
   });
+
+  update = APIEndpoint<Types.UpdateOrderPayload, Types.UpdateOrderResponse>({
+    method: 'patch',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  listRefund = APIEndpoint<Types.ListRefundsPayload, Types.ListRefundsResponse>({
+    method: 'get',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/refunds',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    queryParams: {
+      offset: {
+        type: 'number',
+        required: false,
+      },
+      limit: {
+        type: 'number',
+        required: false,
+      },
+      sort: {
+        type: 'string',
+        required: false,
+      },
+      direction: {
+        type: 'string',
+        required: false,
+      },
+    },
+  });
+
+  getRefund = APIEndpoint<Types.GetRefundPayload, Types.GetRefundResponse>({
+    method: 'get',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/refunds/{refund_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
 }
 
 export default Orders;

--- a/src/lib/ecomm/types.ts
+++ b/src/lib/ecomm/types.ts
@@ -302,8 +302,6 @@ export interface Payment {
   card_last_4: string
 }
 
-export interface Refund {}
-
 export interface OrderItem {
   id: string,
   product_id: string,
@@ -322,6 +320,40 @@ export interface OrderItem {
   total: number,
   combined_weight: number,
   metadata: string
+}
+
+export interface RefundTaxes {
+  id: string,
+  name: string,
+  rate: number,
+  amount: number,
+  provider: 'BUILT_IN' | 'AVALARA' | 'UNKNOWN'
+}
+
+export interface RefundOrderItem {
+  id: string,
+  quantity: number,
+  amount: number,
+  taxes: Array<RefundTaxes>
+}
+
+export interface RefundTaxProvider {
+  provider: 'BUILT_IN' | 'AVALARA' | 'UNKNOWN',
+  avalara_reference_id: string
+}
+
+export interface Refund {
+  id: string,
+  order_id: string,
+  transcation_id: string,
+  reason: string,
+  items: Array<RefundOrderItem>,
+  currency: string,
+  tax_provider: RefundTaxProvider,
+  subtotal: number,
+  taxes: Array<RefundTaxes>,
+  total: number,
+  createD: string
 }
 
 export interface Order {
@@ -391,6 +423,30 @@ export interface UpdateOrderPayload {
 }
 
 export interface UpdateOrderResponse extends Order {}
+
+export interface ListRefundsPayload {
+  site_name: string,
+  order_id: string,
+  offset?: number,
+  limit?: number,
+  sort?: string,
+  direction?: string
+}
+
+export interface ListRefundsResponse {
+  offset: number,
+  limit: number,
+  total_responses: number,
+  results: Array<Refund>
+}
+
+export interface GetRefundPayload {
+  site_name: string,
+  order_id: string,
+  refund_id: string
+}
+
+export type GetRefundResponse = Refund;
 
 export type GetCartResponse = Cart;
 

--- a/tests/ecomm.tests.ts
+++ b/tests/ecomm.tests.ts
@@ -11,6 +11,7 @@ describe('Ecomm tests', () => {
   const gateway_id = "test_gateway";
   const cart_id = 'test_cart';
   const order_id = 'test_order';
+  const refund_id = 'test_refund';
   const session_id = 'test_session';
   const category_id = 'test_category';
   const shipping_id = 'test_shipping';
@@ -411,6 +412,22 @@ describe('Ecomm tests', () => {
   const sort = 'sort';
   const direction = 'asc';
 
+  const address = {
+    first_name: "string",
+      last_name: "string",
+      full_name: "string",
+      address_1: "string",
+      address_2: "string",
+      street_number: "string",
+      street_name: "string",
+      city: "string",
+      sub_locality: "string",
+      region: "string",
+      country: "string",
+      postal_code: "string",
+      phone: "string"
+  }
+
   const order = {
     source: "CHECKOUT",
     mode: "LIVE",
@@ -525,6 +542,67 @@ describe('Ecomm tests', () => {
     limit: limit,
     total_response: 0,
     results: [order]
+  }
+
+  const update_order_item = {
+    id: "string",
+    metadata: "string"
+  }
+
+  const update_order_payload = {
+    email: "string",
+    items: [update_order_item],
+    billing_address: address,
+    shipping_address: address,
+    shipping_instructions: "string",
+    metadata: "string"
+  }
+
+  const refund = {
+    id: "string",
+    order_id: order_id,
+    transaction_id: "string",
+    reason: "string",
+    items: [
+      {
+        id: "string",
+        quantity: 0,
+        amount: 0,
+        taxes: [
+          {
+            id: "string",
+            name: "string",
+            rate: 0,
+            amount: 0,
+            provider: "BUILT_IN"
+          }
+        ]
+      }
+    ],
+    currency: "string",
+    tax_provider: {
+      provider: "BUILT_IN",
+      avalara_reference_id: "string"
+    },
+    subtotal: 0,
+    taxes: [
+      {
+        id: "string",
+        name: "string",
+        rate: 0,
+        amount: 0,
+        provider: "BUILT_IN"
+      }
+    ],
+    total: 0,
+    created: "2024-04-18T18:56:53.920Z"
+  }
+
+  const list_refunds = {
+    offset: offset,
+    limit: limit,
+    total_response: 0,
+    results: [refund]
   }
 
   const gateway = {
@@ -891,6 +969,34 @@ describe('Ecomm tests', () => {
 
     return await duda.ecomm.orders.get({ site_name, order_id })
       .then(res => expect(res).to.eql({ ...order }))
+  })
+
+  it('can update an order', async () => {
+    scope.patch(`/api/sites/multiscreen/${site_name}/ecommerce/orders/${order_id}`, (body) => {
+      expect(body).to.eql({ status: 'IN_PROGRESS', ...update_order_payload })
+      return body
+    }).reply(200, order)
+
+    return await duda.ecomm.orders.update({ site_name, order_id, status: 'IN_PROGRESS', ...update_order_payload })
+  })
+
+  it('can list all refunds', async () => {
+    scope.get(`/api/sites/multiscreen/${site_name}/ecommerce/orders/${order_id}/refunds?offset=${offset}&limit=${limit}&sort=${sort}&direction=${direction}`).reply(200, list_refunds)
+    return await duda.ecomm.orders.listRefund({
+      site_name: site_name,
+      order_id: order_id,
+      offset: offset,
+      limit: limit,
+      sort: sort,
+      direction: direction
+    }).then(res => expect(res).to.eql(list_refunds))
+  })
+
+  it('can get a specific refund', async () => {
+    scope.get(`/api/sites/multiscreen/${site_name}/ecommerce/orders/${order_id}/refunds/${refund_id}`).reply(200, refund)
+
+    return await duda.ecomm.orders.getRefund({ site_name, order_id, refund_id })
+      .then(res => expect(res).to.eql({ ...refund }))
   })
 
   it('can get a payment session', async () => {


### PR DESCRIPTION
- Added List Refunds and Get Refund Endpoints
- Also added Update Order Endpoint to match App Store endpoints
- Updated types.ts file appropriately
- Updated ecomm.tests.ts file to include new endpoint tests
- Updated README file to include new endpoints