### PR TITLE
Ecomm Refund API Endpoints

### DIFF
--- a/src/lib/apps/ecomm/Orders.ts
+++ b/src/lib/apps/ecomm/Orders.ts
@@ -2,8 +2,11 @@ import * as Types from './types';
 import { SubResource } from '../../base';
 import { APIEndpoint } from '../../APIEndpoint';
 import { TokenRequest } from '../types';
+import AppsRefunds from './Refunds';
 
 class AppsOrders extends SubResource {
+  refunds = new AppsRefunds(this.base);
+
   list = APIEndpoint<TokenRequest<Types.ListOrdersPayload>, Types.ListOrdersResponse>({
     method: 'get',
     path: '/site/{site_name}/ecommerce/orders',

--- a/src/lib/apps/ecomm/Refunds.ts
+++ b/src/lib/apps/ecomm/Refunds.ts
@@ -1,0 +1,53 @@
+import * as Types from './types';
+import { SubResource } from '../../base';
+import { APIEndpoint } from '../../APIEndpoint';
+import { TokenRequest } from '../types';
+
+class AppsRefunds extends SubResource {
+  list = APIEndpoint<TokenRequest<Types.ListRefundsPayload>, Types.ListRefundsResponse>({
+    method: 'get',
+    path: '/site/{site_name}/ecommerce/orders/{order_id}/refunds',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+    queryParams: {
+      offset: {
+        type: 'number',
+        required: false,
+      },
+      limit: {
+        type: 'number',
+        required: false,
+      },
+      sort: {
+        type: 'string',
+        required: false,
+      },
+      direction: {
+        type: 'string',
+        required: false,
+      },
+    },
+  });
+
+  get = APIEndpoint<TokenRequest<Types.GetRefundPayload>, Types.GetRefundResponse>({
+    method: 'get',
+    path: '/site/{site_name}/ecommerce/orders/{order_id}/refunds/{refund_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+}
+
+export default AppsRefunds;
+export { AppsRefunds };

--- a/src/lib/ecomm/Orders.ts
+++ b/src/lib/ecomm/Orders.ts
@@ -1,8 +1,11 @@
 import * as Types from './types';
 import Resource from '../base';
 import { APIEndpoint } from '../APIEndpoint';
+import Refunds from './Refunds';
 
 class Orders extends Resource {
+  refunds = new Refunds(this.config);
+
   list = APIEndpoint<Types.ListOrdersPayload, Types.ListOrdersResponse>({
     method: 'get',
     path: '/api/sites/multiscreen/{site_name}/ecommerce/orders',

--- a/src/lib/ecomm/Refunds.ts
+++ b/src/lib/ecomm/Refunds.ts
@@ -1,0 +1,42 @@
+import * as Types from './types';
+import Resource from '../base';
+import { APIEndpoint } from '../APIEndpoint';
+
+class Refunds extends Resource {
+  list = APIEndpoint<Types.ListRefundsPayload, Types.ListRefundsResponse>({
+    method: 'get',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/refunds',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    queryParams: {
+      offset: {
+        type: 'number',
+        required: false,
+      },
+      limit: {
+        type: 'number',
+        required: false,
+      },
+      sort: {
+        type: 'string',
+        required: false,
+      },
+      direction: {
+        type: 'string',
+        required: false,
+      },
+    },
+  });
+
+  get = APIEndpoint<Types.GetRefundPayload, Types.GetRefundResponse>({
+    method: 'get',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/refunds/{refund_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+}
+
+export default Refunds;
+export { Refunds };

--- a/tests/app/ecomm.tests.ts
+++ b/tests/app/ecomm.tests.ts
@@ -828,6 +828,26 @@ describe('App store ecomm tests', () => {
       .then(res => expect(res).to.eql({ ...refund }))
   })
 
+  it('can list all refunds (alternate)', async () => {
+    scope.get(`${base_path}/site/${site_name}/ecommerce/orders/${order_id}/refunds?offset=${offset}&limit=${limit}&sort=${sort}&direction=${direction}`).reply(200, list_refunds)
+    return await duda.appstore.ecomm.orders.refunds.list({
+      site_name: site_name,
+      order_id: order_id,
+      offset: offset,
+      limit: limit,
+      sort: sort,
+      direction: direction,
+      token: token
+    }).then(res => expect(res).to.eql(list_refunds))
+  })
+
+  it('can get a specific refund (alternate)', async () => {
+    scope.get(`${base_path}/site/${site_name}/ecommerce/orders/${order_id}/refunds/${refund_id}`).reply(200, refund)
+
+    return await duda.appstore.ecomm.orders.refunds.get({ site_name, order_id, refund_id, token })
+      .then(res => expect(res).to.eql({ ...refund }))
+  })
+
   it('can get a payment session', async () => {
     scope.get(`${base_path}/site/${site_name}/ecommerce/payment-sessions/${session_id}`).reply(200, payment_session)
     return await duda.appstore.ecomm.payments.get({

--- a/tests/ecomm.tests.ts
+++ b/tests/ecomm.tests.ts
@@ -984,6 +984,25 @@ describe('Ecomm tests', () => {
       .then(res => expect(res).to.eql({ ...refund }))
   })
 
+  it('can list all refunds (alternate)', async () => {
+    scope.get(`/api/sites/multiscreen/${site_name}/ecommerce/orders/${order_id}/refunds?offset=${offset}&limit=${limit}&sort=${sort}&direction=${direction}`).reply(200, list_refunds)
+    return await duda.ecomm.orders.refunds.list({
+      site_name: site_name,
+      order_id: order_id,
+      offset: offset,
+      limit: limit,
+      sort: sort,
+      direction: direction
+    }).then(res => expect(res).to.eql(list_refunds))
+  })
+
+  it('can get a specific refund (alternate)', async () => {
+    scope.get(`/api/sites/multiscreen/${site_name}/ecommerce/orders/${order_id}/refunds/${refund_id}`).reply(200, refund)
+
+    return await duda.ecomm.orders.refunds.get({ site_name, order_id, refund_id })
+      .then(res => expect(res).to.eql({ ...refund }))
+  })
+
   it('can get a payment session', async () => {
     scope.get(`/api.duda.co/api/sites/multiscreen/${site_name}/ecommerce/payment-sessions/${session_id}`).reply(200, payment_session)
     return await duda.ecomm.payments.get({


### PR DESCRIPTION
- Added alternate versions of ecomm refund api endpoints to reflect the actual implementation of the api (paths)
- Added new tests for these alternate versions