### PR TITLE
Get Site By External ID Endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import/no-unresolved,
 import/extensions,
 import/prefer-default-export
 */
-import EventEmitter from 'events';
+import {EventEmitter} from 'events';
 import Accounts from './lib/accounts/Accounts';
 import Apps, { DudaAppConfig } from './lib/apps/Apps';
 import Blog from './lib/blog/Blog';

--- a/src/lib/apps/Apps.ts
+++ b/src/lib/apps/Apps.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import {EventEmitter} from 'events';
 // import * as apps from './types';
 import Resource, { Config } from '../base';
 import { APIEndpoint } from '../APIEndpoint';

--- a/src/lib/base.ts
+++ b/src/lib/base.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file, no-underscore-dangle */
 
-import EventEmitter from 'events';
+import {EventEmitter} from 'events';
 import { RequestOptions } from './http';
 import { APIEndpointDefinition } from './APIEndpoint';
 

--- a/src/lib/sites/types.ts
+++ b/src/lib/sites/types.ts
@@ -234,6 +234,8 @@ export type GetSiteByExtIDPayload = {
   external_uid: string,
 }
 
+export type GetSiteByExtIDResponse = Array<string>;
+
 export interface CreateSitePayload extends Site {
   template_id: string | number,
   url?: string,


### PR DESCRIPTION
- Updated response of the endpoint to correctly return an array of string
- Minor changes to EvenEmitter import to allow for proper testing in the partner-sdk-test repo