### PR TITLE
Create External Order Appstore Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1165,16 +1165,16 @@ duda.ecomm.orders.list({ site_name: site_name });
 duda.ecomm.orders.get({ site_name: site_name, order_id: order_id });
 ```
 
-## Create Order
+## Create External Order
 
-[Create Order Reference](https://developer.duda.co/reference/create-external-order)
+[Create External Order Reference](https://developer.duda.co/reference/create-external-order)
 
 ### Request
 
 `POST https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/orders`
 
 ```typescript
-duda.ecomm.orders.post({ site_name: site_name });
+duda.ecomm.orders.create({ site_name: site_name });
 ```
 
 ## Update Order
@@ -3277,6 +3277,18 @@ duda.appstore.ecomm.orders.list({ site_name: site_name });
 
 ```typescript
 duda.appstore.ecomm.orders.get({ site_name: site_name, order_id: order_id });
+```
+
+## Create External Order
+
+[Create External Order Reference](https://developer.duda.co/reference/app-create-external-order)
+
+### Request
+
+`POST https://api-sandbox.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/orders`
+
+```typescript
+duda.appstore.ecomm.orders.create({ site_name: site_name });
 ```
 
 ## Update Order

--- a/src/lib/apps/ecomm/Orders.ts
+++ b/src/lib/apps/ecomm/Orders.ts
@@ -51,6 +51,19 @@ class AppsOrders extends SubResource {
     },
   });
 
+  create = APIEndpoint<TokenRequest<Types.CreateOrderPayload>, Types.CreateOrderResponse>({
+    method: 'post',
+    path: '/site/{site_name}/ecommerce/orders',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
   update = APIEndpoint<TokenRequest<Types.UpdateOrderPayload>, Types.UpdateOrderResponse>({
     method: 'patch',
     path: '/site/{site_name}/ecommerce/orders/{order_id}',

--- a/tests/app/ecomm.tests.ts
+++ b/tests/app/ecomm.tests.ts
@@ -378,6 +378,38 @@ describe('App store ecomm tests', () => {
     results: [order]
   }
 
+  const create_order_options = {
+    name: "string",
+    value: "string"
+  }
+
+  const create_order_item = {
+    product_id: "string",
+    variation_id: "string",
+    external_product_id: "string",
+    external_variation_id: "string",
+    name: "string",
+    image: "string",
+    options: [create_order_options],
+    quantity: 1,
+    unit_price: 1,
+    unit_dimensions: {
+      height: 0,
+      width: 0,
+      length: 0
+    },
+  }
+
+  const create_order_payload = {
+    curreny: "string",
+    invoice_number: "string",
+    email: "string",
+    items: [create_order_item],
+    billing_address: address,
+    shipping_address: address,
+    shipping_instructions: "string",
+  }
+
   const update_order_item = {
     id: "string",
     metadata: "string"
@@ -870,6 +902,15 @@ describe('App store ecomm tests', () => {
 
     return await duda.appstore.ecomm.orders.get({ site_name, order_id, token })
       .then(res => expect(res).to.eql({ ...order }))
+  })
+
+  it('can create an external order', async () => {
+    scope.post(`${base_path}/site/${site_name}/ecommerce/orders`, (body) => {
+      expect(body).to.eql({ mode: 'LIVE', status: 'IN_PROGRESS', ...create_order_payload })
+      return body
+    }).reply(200, order)
+
+    return await duda.appstore.ecomm.orders.create({ site_name, mode: 'LIVE', status: 'IN_PROGRESS', token, ...create_order_payload })
   })
 
   it('can update an order', async () => {

--- a/tests/ecomm.tests.ts
+++ b/tests/ecomm.tests.ts
@@ -1199,7 +1199,7 @@ describe('Ecomm tests', () => {
       .then(res => expect(res).to.eql({ ...order }))
   })
 
-  it('can create an order', async () => {
+  it('can create an external order', async () => {
     scope.post(`/api/sites/multiscreen/${site_name}/ecommerce/orders`, (body) => {
       expect(body).to.eql({ mode: 'LIVE', status: 'IN_PROGRESS', ...create_order_payload })
       return body


### PR DESCRIPTION
- Added Create External Order endpoint to the Appstore side
- Added appropriate tests to testing file
- Updated README to include the new endpoint
- Some general README fixes