### PR TITLE
Order Fulfillment Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # @dudadev/partner-api
 
-The `@dudadev/partner-api` library provides convenient access to Duda's public APIs from applications written in
-server-side Javascript.
+The `@dudadev/partner-api` library provides convenient access to Duda's public APIs from applications written in server-side Javascript.
 
 1. [Requirements](#requirements)
 2. [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -1217,6 +1217,62 @@ duda.ecomm.orders.getRefund({
 });
 ```
 
+## List Order Fulfillments
+
+[List Order Fulfillments Reference](https://developer.duda.co/reference/ecommerce-list-order-fulfillments#/)
+
+### Request
+
+`GET https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/fulfillments`
+
+```typescript
+duda.ecomm.orders.listFulfillments({ site_name: site_name, order_id: order_id });
+```
+
+## Get Order Fulfillment
+
+[Get Order Fulfillment Reference](https://developer.duda.co/reference/ecommerce-get-order-fulfillment#/)
+
+### Request
+
+`GET https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/fulfillments/{fulfillment_id}`
+
+```typescript
+duda.ecomm.orders.getFulfillment({
+  site_name: site_name,
+  order_id: order_id,
+  fulfillment_id: fulfillment_id
+});
+```
+
+## Create Order Fulfillment
+
+[Create Order Fulfillment Reference](https://developer.duda.co/reference/ecommerce-create-order-fulfillment#/)
+
+### Request
+
+`POST https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/fulfillments`
+
+```typescript
+duda.ecomm.orders.createFulfillment({ site_name: site_name, order_id: order_id });
+```
+
+## Update Order Fulfillment
+
+[Update Order Fulfillment Reference](https://developer.duda.co/reference/ecommerce-update-order-fulfillment#/)
+
+### Request
+
+`PATCH https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/fulfillments/{fulfillment_id}`
+
+```typescript
+duda.ecomm.orders.updateFulfillment({
+  site_name: site_name,
+  order_id: order_id,
+  fulfillment_id: fulfillment_id
+});
+```
+
 # eComm Payment Gateways
 
 ## List Payment Gateways
@@ -3361,6 +3417,62 @@ duda.appstore.ecomm.orders.getRefund({
   site_name: site_name,
   order_id: order_id,
   refund_id: refund_id,
+});
+```
+
+## List Order Fulfillments
+
+[List Order Fulfillments Reference](https://developer.duda.co/reference/app-ecommerce-list-order-fulfillments#/)
+
+### Request
+
+`GET https://api-sandbox.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/orders/${order_id}/fulfillments`
+
+```typescript
+duda.appstore.ecomm.orders.listFulfillments({ site_name: site_name, order_id: order_id });
+```
+
+## Get Order Fulfillment
+
+[Get Order Fulfillment Reference](https://developer.duda.co/reference/app-ecommerce-get-order-fulfillment#/)
+
+### Request
+
+`GET https://api-sandbox.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/orders/${order_id}/fulfillments/{fulfillment_id}`
+
+```typescript
+duda.appstore.ecomm.orders.getFulfillment({
+  site_name: site_name,
+  order_id: order_id,
+  fulfillment_id: fulfillment_id
+});
+```
+
+## Create Order Fulfillment
+
+[Create Order Fulfillment Reference](https://developer.duda.co/reference/app-ecommerce-create-order-fulfillment#/)
+
+### Request
+
+`POST https://api-sandbox.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/orders/${order_id}/fulfillments`
+
+```typescript
+duda.appstore.ecomm.orders.createFulfillment({ site_name: site_name, order_id: order_id });
+```
+
+## Update Order Fulfillment
+
+[Update Order Fulfillment Reference](https://developer.duda.co/reference/app-ecommerce-update-order-fulfillment#/)
+
+### Request
+
+`PATCH https://api-sandbox.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/orders/${order_id}/fulfillments/{fulfillment_id}`
+
+```typescript
+duda.appstore.ecomm.orders.updateFulfillment({
+  site_name: site_name,
+  order_id: order_id,
+  fulfillment_id: fulfillment_id
 });
 ```
 

--- a/src/lib/apps/ecomm/Orders.ts
+++ b/src/lib/apps/ecomm/Orders.ts
@@ -120,6 +120,76 @@ class AppsOrders extends SubResource {
       },
     },
   });
+
+  listFulfillments = APIEndpoint<TokenRequest<Types.ListOrderFulfillmentsPayload>, Types.ListOrderFulfillmentsResponse>({
+    method: 'get',
+    path: '/site/{site_name}/ecommerce/orders/{order_id}/fulfillments',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+    queryParams: {
+      offset: {
+        type: 'number',
+        required: false,
+      },
+      limit: {
+        type: 'number',
+        required: false,
+      },
+      sort: {
+        type: 'string',
+        required: false,
+      },
+      direction: {
+        type: 'string',
+        required: false,
+      },
+    },
+  });
+
+  getFulfillment = APIEndpoint<TokenRequest<Types.GetOrderFulfillmentPayload>, Types.GetOrderFulfillmentResponse>({
+    method: 'get',
+    path: '/site/{site_name}/ecommerce/orders/{order_id}/fulfillments/{fulfillment_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    }
+  });
+
+  createFulfillment = APIEndpoint<TokenRequest<Types.CreateOrderFulfillmentPayload>, Types.CreateOrderFulfillmentResponse>({
+    method: 'post',
+    path: '/site/{site_name}/ecommerce/orders/{order_id}/fulfillments',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    }
+  });
+
+  updateFulfillment = APIEndpoint<TokenRequest<Types.UpdateOrderFulfillmentPayload>, Types.UpdateOrderFulfillmentResponse>({
+    method: 'patch',
+    path: '/site/{site_name}/ecommerce/orders/{order_id}/fulfillments/{fulfillment_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    }
+  });
 }
 
 export default AppsOrders;

--- a/src/lib/ecomm/Orders.ts
+++ b/src/lib/ecomm/Orders.ts
@@ -89,6 +89,56 @@ class Orders extends Resource {
       host: 'api.duda.co',
     },
   });
+
+  listFulfillments = APIEndpoint<Types.ListOrderFulfillmentsPayload, Types.ListOrderFulfillmentsResponse>({
+    method: 'get',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/fulfillments',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    queryParams: {
+      offset: {
+        type: 'number',
+        required: false,
+      },
+      limit: {
+        type: 'number',
+        required: false,
+      },
+      sort: {
+        type: 'string',
+        required: false,
+      },
+      direction: {
+        type: 'string',
+        required: false,
+      },
+    },
+  });
+
+  getFulfillment = APIEndpoint<Types.GetOrderFulfillmentPayload, Types.GetOrderFulfillmentResponse>({
+    method: 'get',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/fulfillments/{fulfillment_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  createFulfillment = APIEndpoint<Types.CreateOrderFulfillmentPayload, Types.CreateOrderFulfillmentResponse>({
+    method: 'post',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/fulfillments',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  updateFulfillment = APIEndpoint<Types.UpdateOrderFulfillmentPayload, Types.UpdateOrderFulfillmentResponse>({
+    method: 'patch',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/fulfillments/{fulfillment_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
 }
 
 export default Orders;

--- a/src/lib/ecomm/types.ts
+++ b/src/lib/ecomm/types.ts
@@ -507,10 +507,10 @@ export interface FulfillmentTracking {
 }
 
 export interface Fulfillment {
-  status: 'IN_PROGRESS' | 'FULFILLED' | string,
-  method: 'EMAIL_MESSAGE' | 'SHIPMENT' | 'PICKUP' | string,
-  items: Array<FulfillmentItems>,
-  tracking: FulfillmentTracking
+  status?: 'IN_PROGRESS' | 'FULFILLED' | string,
+  method?: 'EMAIL_MESSAGE' | 'SHIPMENT' | 'PICKUP' | string,
+  items?: Array<FulfillmentItems>,
+  tracking?: FulfillmentTracking
 }
 
 export interface FulfillmentResponse extends Fulfillment {
@@ -552,8 +552,8 @@ export interface UpdateOrderFulfillmentPayload {
   site_name: string,
   order_id: string,
   fulfillment_id: string,
-  status: 'IN_PROGRESS' | 'FULFILLED' | string,
-  tracking: FulfillmentTracking
+  status?: 'IN_PROGRESS' | 'FULFILLED' | string,
+  tracking?: FulfillmentTracking
 }
 
 export interface UpdateOrderFulfillmentResponse extends FulfillmentResponse {}

--- a/src/lib/ecomm/types.ts
+++ b/src/lib/ecomm/types.ts
@@ -495,6 +495,69 @@ export interface GetRefundPayload {
 
 export type GetRefundResponse = Refund;
 
+export interface FulfillmentItems {
+  id: string,
+  quantity: number
+}
+
+export interface FulfillmentTracking {
+  carrier: string,
+  number: string,
+  url: string
+}
+
+export interface Fulfillment {
+  status: 'IN_PROGRESS' | 'FULFILLED' | string,
+  method: 'EMAIL_MESSAGE' | 'SHIPMENT' | 'PICKUP' | string,
+  items: Array<FulfillmentItems>,
+  tracking: FulfillmentTracking
+}
+
+export interface FulfillmentResponse extends Fulfillment {
+  id: string
+}
+
+export interface ListOrderFulfillmentsPayload {
+  site_name: string,
+  order_id: string,
+  limit?: number,
+  offset?: number,
+  sort?: 'title' | string,
+  direction?: 'asc' | 'desc',
+}
+
+export interface ListOrderFulfillmentsResponse {
+  offset: number,
+  limit: number,
+  total_responses: number,
+  results: Array<FulfillmentResponse>
+}
+
+export interface GetOrderFulfillmentPayload {
+  site_name: string,
+  order_id: string,
+  fulfillment_id: string
+}
+
+export interface GetOrderFulfillmentResponse extends FulfillmentResponse {}
+
+export interface CreateOrderFulfillmentPayload extends Fulfillment {
+  site_name: string,
+  order_id: string
+}
+
+export interface CreateOrderFulfillmentResponse extends FulfillmentResponse {}
+
+export interface UpdateOrderFulfillmentPayload {
+  site_name: string,
+  order_id: string,
+  fulfillment_id: string,
+  status: 'IN_PROGRESS' | 'FULFILLED' | string,
+  tracking: FulfillmentTracking
+}
+
+export interface UpdateOrderFulfillmentResponse extends FulfillmentResponse {}
+
 export type GetCartResponse = Cart;
 
 interface BusinessAddress {

--- a/tests/app/ecomm.tests.ts
+++ b/tests/app/ecomm.tests.ts
@@ -10,6 +10,7 @@ describe('App store ecomm tests', () => {
   const choice_id = 'string';
   const order_id = 'test_order';
   const refund_id = 'test_refund';
+  const fulfillment_id = 'fulfil_test';
   const session_id = 'test_session';
   const gateway_id = "test_gateway";
   const cart_id = 'test_cart';
@@ -541,6 +542,55 @@ describe('App store ecomm tests', () => {
     results: [refund]
   }
 
+  const fulfillment = {
+    id: "fulfil_test",
+    status: "FULFILLED",
+    method: "SHIPMENT",
+    items: [
+      {
+        id: "item_123",
+        quantity: 2
+      }
+    ],
+    tracking: {
+      carrier: "Canada Post",
+      number: "12345",
+      url: "https://example.com/12345"
+    }
+  }
+
+  const list_fulfillments = {
+    offset,
+    limit,
+    total_response: 1,
+    results: [fulfillment]
+  }
+
+  const create_order_fulfillment_payload = {
+    status: "FULFILLED",
+    method: "SHIPMENT",
+    items: [
+      {
+        id: "item_123",
+        quantity: 2
+      }
+    ],
+    tracking: {
+      carrier: "Canada Post",
+      number: "12345",
+      url: "https://example.com/12345"
+    }
+  }
+
+  const update_order_fulfillment_payload = {
+    status: "FULFILLED",
+    tracking: {
+      carrier: "Canada Post",
+      number: "12345",
+      url: "https://example.com/12345"
+    }
+  }
+
   const gateway = {
     live_payment_methods_url: 'https://example.org/path/to/gateway',
     test_payment_methods_url: 'https://test.example.org/path/to/gateway',
@@ -970,6 +1020,44 @@ describe('App store ecomm tests', () => {
 
     return await duda.appstore.ecomm.orders.refunds.get({ site_name, order_id, refund_id, token })
       .then(res => expect(res).to.eql({ ...refund }))
+  })
+
+  it('can list all order fulfillments', async () => {
+    scope.get(`${base_path}/site/${site_name}/ecommerce/orders/${order_id}/fulfillments?offset=${offset}&limit=${limit}&sort=${sort}&direction=${direction}`).reply(200, list_fulfillments)
+    return await duda.appstore.ecomm.orders.listFulfillments({
+      site_name,
+      order_id,
+      offset,
+      limit,
+      sort,
+      direction,
+      token
+    }).then(res => expect(res).to.eql(list_fulfillments))
+  })
+
+  it('can get a specific order fulfillment', async () => {
+    scope.get(`${base_path}/site/${site_name}/ecommerce/orders/${order_id}/fulfillments/${fulfillment_id}`).reply(200, fulfillment)
+
+    return await duda.appstore.ecomm.orders.getFulfillment({ site_name, order_id, fulfillment_id, token })
+      .then(res => expect(res).to.eql({ ...fulfillment }))
+  })
+
+  it('can create an order fulfillment', async () => {
+    scope.post(`${base_path}/site/${site_name}/ecommerce/orders/${order_id}/fulfillments`, (body) => {
+      expect(body).to.eql({ ...create_order_fulfillment_payload })
+      return body
+    }).reply(201, fulfillment)
+
+    return await duda.appstore.ecomm.orders.createFulfillment({ site_name, order_id, token, ...create_order_fulfillment_payload })
+  })
+
+  it('can update an order fulfillment', async () => {
+    scope.patch(`${base_path}/site/${site_name}/ecommerce/orders/${order_id}/fulfillments/${fulfillment_id}`, (body) => {
+      expect(body).to.eql({ ...update_order_fulfillment_payload })
+      return body
+    }).reply(200, fulfillment)
+
+    return await duda.appstore.ecomm.orders.updateFulfillment({ site_name, order_id, fulfillment_id, token, ...update_order_fulfillment_payload })
   })
 
   it('can get a payment session', async () => {


### PR DESCRIPTION
- Added List, Get, Create, and Update Order Fulfillment Endpoints to partner and app side
- Updated types files to includes responses and payload for these endpoints
- Updated tests file to include tests for these endpoints
- Updated README to include new endpoints