### PR TITLE
Soleng 1161

### DIFF
--- a/README.md
+++ b/README.md
@@ -1188,7 +1188,7 @@ duda.ecomm.orders.create({ site_name: site_name });
 duda.ecomm.orders.update({ site_name: site_name, order_id: order_id });
 ```
 
-## List Refunds
+## List Refunds (DEPRECATED -- See updated endpoint [here](#list-refunds))
 
 [List Refunds Reference](https://developer.duda.co/reference/list-refunds)
 
@@ -1200,7 +1200,7 @@ duda.ecomm.orders.update({ site_name: site_name, order_id: order_id });
 duda.ecomm.orders.listRefunds({ site_name: site_name, order_id: order_id });
 ```
 
-## Get Refund
+## Get Refund (DEPRECATED -- See updated endpoint [here](#get-refund))
 
 [Get Refund Reference](https://developer.duda.co/reference/get-refund)
 
@@ -1214,6 +1214,46 @@ duda.ecomm.orders.getRefund({
   order_id: order_id,
   refund_id: refund_id,
 });
+```
+
+## List Refunds
+
+[List Refunds Reference](https://developer.duda.co/reference/list-refunds)
+
+### Request
+
+`GET https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/refunds`
+
+```typescript
+duda.ecomm.orders.refunds.list({ site_name: site_name, order_id: order_id });
+```
+
+## Get Refund
+
+[Get Refund Reference](https://developer.duda.co/reference/get-refund)
+
+### Request
+
+`GET https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/refunds/{refund_id}`
+
+```typescript
+duda.ecomm.orders.refunds.get({
+  site_name: site_name,
+  order_id: order_id,
+  refund_id: refund_id,
+});
+```
+
+## Create Refund
+
+[Create Refund Reference](https://developer.duda.co/reference/ecommerce-create-refund#/)
+
+### Request
+
+`POST https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/refunds`
+
+```typescript
+duda.ecomm.orders.refunds.create({ site_name: site_name, order_id: order_id });
 ```
 
 ## List Order Fulfillments
@@ -3388,7 +3428,7 @@ duda.appstore.ecomm.orders.create({ site_name: site_name });
 duda.appstore.ecomm.orders.update({ site_name: site_name, order_id: order_id });
 ```
 
-## List Refunds
+## List Refunds (DEPRECATED -- See updated endpoint [here](#list-refunds-1))
 
 [List Refunds Reference](https://developer.duda.co/reference/app-list-refunds)
 
@@ -3403,7 +3443,7 @@ duda.appstore.ecomm.orders.listRefunds({
 });
 ```
 
-## Get Refund
+## Get Refund (DEPRECATED -- See updated endpoint [here](#get-refund-1))
 
 [Get Refund Reference](https://developer.duda.co/reference/app-get-refund)
 
@@ -3416,6 +3456,52 @@ duda.appstore.ecomm.orders.getRefund({
   site_name: site_name,
   order_id: order_id,
   refund_id: refund_id,
+});
+```
+
+## List Refunds
+
+[List Refunds Reference](https://developer.duda.co/reference/app-list-refunds)
+
+### Request
+
+`GET https://api-sandbox.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/orders/{order_id}/refunds`
+
+```typescript
+duda.appstore.ecomm.orders.refunds.list({
+  site_name: site_name,
+  order_id: order_id,
+});
+```
+
+## Get Refund
+
+[Get Refund Reference](https://developer.duda.co/reference/app-get-refund)
+
+### Request
+
+`GET https://api-sandbox.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/orders/{order_id}/refunds/{refund_id}`
+
+```typescript
+duda.appstore.ecomm.orders.refunds.get({
+  site_name: site_name,
+  order_id: order_id,
+  refund_id: refund_id,
+});
+```
+
+## Create Refund
+
+[Create Refund Reference](https://developer.duda.co/reference/app-ecomm-create-refund#/)
+
+### Request
+
+`POST https://api-sandbox.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/orders/{order_id}/refunds`
+
+```typescript
+duda.appstore.ecomm.orders.refunds.create({
+  site_name: site_name,
+  order_id: order_id,
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -1238,7 +1238,7 @@ duda.ecomm.orders.create({ site_name: site_name });
 duda.ecomm.orders.update({ site_name: site_name, order_id: order_id });
 ```
 
-## List Refunds (DEPRECATED -- See updated endpoint [here](#list-refunds))
+## List Refunds (DEPRECATED -- See updated method [here](#list-refunds))
 
 [List Refunds Reference](https://developer.duda.co/reference/list-refunds)
 
@@ -1250,7 +1250,7 @@ duda.ecomm.orders.update({ site_name: site_name, order_id: order_id });
 duda.ecomm.orders.listRefunds({ site_name: site_name, order_id: order_id });
 ```
 
-## Get Refund (DEPRECATED -- See updated endpoint [here](#get-refund))
+## Get Refund (DEPRECATED -- See updated method [here](#get-refund))
 
 [Get Refund Reference](https://developer.duda.co/reference/get-refund)
 
@@ -3478,7 +3478,7 @@ duda.appstore.ecomm.orders.create({ site_name: site_name });
 duda.appstore.ecomm.orders.update({ site_name: site_name, order_id: order_id });
 ```
 
-## List Refunds (DEPRECATED -- See updated endpoint [here](#list-refunds-1))
+## List Refunds (DEPRECATED -- See updated method [here](#list-refunds-1))
 
 [List Refunds Reference](https://developer.duda.co/reference/app-list-refunds)
 
@@ -3493,7 +3493,7 @@ duda.appstore.ecomm.orders.listRefunds({
 });
 ```
 
-## Get Refund (DEPRECATED -- See updated endpoint [here](#get-refund-1))
+## Get Refund (DEPRECATED -- See updated method [here](#get-refund-1))
 
 [Get Refund Reference](https://developer.duda.co/reference/app-get-refund)
 

--- a/README.md
+++ b/README.md
@@ -674,6 +674,56 @@ duda.pages.elements.delete({
 });
 ```
 
+# Footer Page Elements
+
+## List Footer Page Elements
+
+[List Footer Page Elements Reference](https://developer.duda.co/update/reference/page-elements-list-footer-page-elements#/)
+
+### Request
+
+`GET https://api.duda.co/api/sites/multiscreen/{site_name}/footer/elements`
+
+```typescript
+duda.pages.footer.list({ site_name: site_name });
+```
+
+## Create Footer Page Element
+
+[Create Footer Page Element Reference](https://developer.duda.co/update/reference/page-elements-create-footer-page-element#/)
+
+### Request
+
+`POST https://api.duda.co/api/sites/multiscreen/{site_name}/footer/elements`
+
+```typescript
+duda.pages.footer.create({ site_name: site_name });
+```
+
+## Update Footer Page Element
+
+[Update Footer Page Element Reference](https://developer.duda.co/update/reference/page-elements-update-footer-page-element#/)
+
+### Request
+
+`PUT https://api.duda.co/api/sites/multiscreen/{site_name}/footer/elements/{element_id}`
+
+```typescript
+duda.pages.footer.update({ site_name: site_name, element_id: element_id });
+```
+
+## Delete Footer Page Element
+
+[Delete Footer Page Element Reference](https://developer.duda.co/update/reference/page-elements-delete-footer-page-element#/)
+
+### Request
+
+`DELETE https://api.duda.co/api/sites/multiscreen/{site_name}/footer/elements/{element_id}`
+
+```typescript
+duda.pages.footer.delete({ site_name: site_name, element_id: element_id });
+```
+
 # Sections
 
 ## List Sections

--- a/src/lib/apps/ecomm/Refunds.ts
+++ b/src/lib/apps/ecomm/Refunds.ts
@@ -47,6 +47,19 @@ class AppsRefunds extends SubResource {
       },
     },
   });
+
+  create = APIEndpoint<TokenRequest<Types.CreateRefundPayload>, Types.CreateRefundResponse>({
+    method: 'post',
+    path: '/site/{site_name}/ecommerce/orders/{order_id}/refunds',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
 }
 
 export default AppsRefunds;

--- a/src/lib/ecomm/Refunds.ts
+++ b/src/lib/ecomm/Refunds.ts
@@ -36,6 +36,14 @@ class Refunds extends Resource {
       host: 'api.duda.co',
     },
   });
+
+  create = APIEndpoint<Types.CreateRefundPayload, Types.CreateRefundResponse>({
+    method: 'post',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/refunds',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
 }
 
 export default Refunds;

--- a/src/lib/ecomm/types.ts
+++ b/src/lib/ecomm/types.ts
@@ -495,6 +495,21 @@ export interface GetRefundPayload {
 
 export type GetRefundResponse = Refund;
 
+export interface CreateRefundOrderItem {
+  id: string,
+  quantity: number
+}
+
+export interface CreateRefundPayload {
+  site_name: string,
+  order_id: string,
+  reason?: string,
+  notify_customer?: boolean,
+  items: Array<CreateRefundOrderItem>,
+}
+
+export type CreateRefundResponse = Refund;
+
 export interface FulfillmentItems {
   id: string,
   quantity: number

--- a/src/lib/pages/Footer.ts
+++ b/src/lib/pages/Footer.ts
@@ -1,0 +1,41 @@
+import * as Types from './types';
+import Resource from '../base';
+
+import { APIEndpoint } from '../APIEndpoint';
+
+class Footer extends Resource {
+  list = APIEndpoint<Types.ListFooterPageElementPayload, Types.ListFooterPageElementResponse>({
+    method: 'get',
+    path: '/api/sites/multiscreen/{site_name}/footer/elements',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  create = APIEndpoint<Types.CreateFooterPageElementPayload, Types.CreateFooterPageElementResponse>({
+    method: 'post',
+    path: '/api/sites/multiscreen/{site_name}/footer/elements',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  update = APIEndpoint<Types.UpdateFooterPageElementPayload, Types.UpdateFooterPageElementResponse>({
+    method: 'put',
+    path: '/api/sites/multiscreen/{site_name}/footer/elements/{element_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  delete = APIEndpoint<Types.DeleteFooterPageElementPayload, Types.DeleteFooterPageElementResponse>({
+    method: 'delete',
+    path: '/api/sites/multiscreen/{site_name}/footer/elements/{element_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+}
+
+export default Footer;
+export { Footer };

--- a/src/lib/pages/Pages.ts
+++ b/src/lib/pages/Pages.ts
@@ -2,6 +2,7 @@ import * as Types from './types';
 import Resource from '../base';
 import PagesV2 from './v2';
 import Elements from './elements';
+import Footer from './Footer';
 
 import { APIEndpoint } from '../APIEndpoint';
 
@@ -9,6 +10,8 @@ class Pages extends Resource {
   v2 = new PagesV2(this.config);
 
   elements = new Elements(this.config);
+
+  footer = new Footer(this.config);
 
   list = APIEndpoint<Types.V1.ListPagesPayload, Types.V1.ListPagesResponse>({
     method: 'get',

--- a/src/lib/pages/types.ts
+++ b/src/lib/pages/types.ts
@@ -1,3 +1,5 @@
+import Footer from "./Footer";
+
 export namespace V1 {
   export interface Page {
     page_title?: string,
@@ -125,7 +127,7 @@ export interface CreatePageElementPayload {
   site_name: string,
   page_uuid: string,
   element_source_id: string,
-  type: 'SECTION',
+  type: 'SECTION' | string,
   next_sibling_id?: string,
   parent_element_id?: string
 }
@@ -136,7 +138,7 @@ export interface UpdatePageElementPayload {
   site_name: string,
   page_uuid: string,
   element_id: string,
-  type: 'SECTION',
+  type: 'SECTION' | string,
   next_sibling_id?: string,
   parent_element_id?: string
 }
@@ -150,3 +152,41 @@ export interface DeletePageElementPayload {
 }
 
 export type DeletePageElementResponse = void;
+
+export interface FooterPageElement {
+  element_id: string,
+  element_source_id: string,
+  next_sibling_id: string
+}
+
+export interface ListFooterPageElementPayload {
+  site_name: string
+}
+
+export interface ListFooterPageElementResponse {
+  results: Array<FooterPageElement>
+}
+
+export interface CreateFooterPageElementPayload {
+  site_name: string,
+  element_source_id: string,
+  next_sibling_id: string
+}
+
+export interface CreateFooterPageElementResponse extends FooterPageElement {}
+
+export interface UpdateFooterPageElementPayload {
+  site_name: string,
+  element_id: string,
+  next_sibling_id: string,
+  parent_element_id: string
+}
+
+export interface UpdateFooterPageElementResponse extends FooterPageElement {}
+
+export interface DeleteFooterPageElementPayload {
+  site_name: string,
+  element_id: string
+}
+
+export type DeleteFooterPageElementResponse = void;

--- a/tests/app/ecomm.tests.ts
+++ b/tests/app/ecomm.tests.ts
@@ -542,6 +542,17 @@ describe('App store ecomm tests', () => {
     results: [refund]
   }
 
+  const create_refund_payload = {
+    reason: "string",
+    notify_customer: true,
+    items: [
+      {
+        id: "string",
+        quantity: 0
+      }
+    ]
+  }
+
   const fulfillment = {
     id: "fulfil_test",
     status: "FULFILLED",
@@ -982,9 +993,29 @@ describe('App store ecomm tests', () => {
     return await duda.appstore.ecomm.orders.update({ site_name, order_id, token, status: 'IN_PROGRESS', ...update_order_payload })
   })
 
-  it('can list all refunds', async () => {
+  it('can list all refunds (DEPRECATED)', async () => {
     scope.get(`${base_path}/site/${site_name}/ecommerce/orders/${order_id}/refunds?offset=${offset}&limit=${limit}&sort=${sort}&direction=${direction}`).reply(200, list_refunds)
     return await duda.appstore.ecomm.orders.listRefund({
+      site_name: site_name,
+      order_id: order_id,
+      offset: offset,
+      limit: limit,
+      sort: sort,
+      direction: direction,
+      token: token
+    }).then(res => expect(res).to.eql(list_refunds))
+  })
+
+  it('can get a specific refund (DEPRECATED)', async () => {
+    scope.get(`${base_path}/site/${site_name}/ecommerce/orders/${order_id}/refunds/${refund_id}`).reply(200, refund)
+
+    return await duda.appstore.ecomm.orders.getRefund({ site_name, order_id, refund_id, token })
+      .then(res => expect(res).to.eql({ ...refund }))
+  })
+
+  it('can list all refunds', async () => {
+    scope.get(`${base_path}/site/${site_name}/ecommerce/orders/${order_id}/refunds?offset=${offset}&limit=${limit}&sort=${sort}&direction=${direction}`).reply(200, list_refunds)
+    return await duda.appstore.ecomm.orders.refunds.list({
       site_name: site_name,
       order_id: order_id,
       offset: offset,
@@ -998,28 +1029,17 @@ describe('App store ecomm tests', () => {
   it('can get a specific refund', async () => {
     scope.get(`${base_path}/site/${site_name}/ecommerce/orders/${order_id}/refunds/${refund_id}`).reply(200, refund)
 
-    return await duda.appstore.ecomm.orders.getRefund({ site_name, order_id, refund_id, token })
-      .then(res => expect(res).to.eql({ ...refund }))
-  })
-
-  it('can list all refunds (alternate)', async () => {
-    scope.get(`${base_path}/site/${site_name}/ecommerce/orders/${order_id}/refunds?offset=${offset}&limit=${limit}&sort=${sort}&direction=${direction}`).reply(200, list_refunds)
-    return await duda.appstore.ecomm.orders.refunds.list({
-      site_name: site_name,
-      order_id: order_id,
-      offset: offset,
-      limit: limit,
-      sort: sort,
-      direction: direction,
-      token: token
-    }).then(res => expect(res).to.eql(list_refunds))
-  })
-
-  it('can get a specific refund (alternate)', async () => {
-    scope.get(`${base_path}/site/${site_name}/ecommerce/orders/${order_id}/refunds/${refund_id}`).reply(200, refund)
-
     return await duda.appstore.ecomm.orders.refunds.get({ site_name, order_id, refund_id, token })
       .then(res => expect(res).to.eql({ ...refund }))
+  })
+
+  it('can create a refund', async () => {
+    scope.post(`${base_path}/site/${site_name}/ecommerce/orders/${order_id}/refunds`, (body) => {
+      expect(body).to.eql({ ...create_refund_payload })
+      return body
+    }).reply(201, refund)
+
+    return await duda.appstore.ecomm.orders.refunds.create({ site_name, order_id, token, ...create_refund_payload })
   })
 
   it('can list all order fulfillments', async () => {

--- a/tests/ecomm.tests.ts
+++ b/tests/ecomm.tests.ts
@@ -716,6 +716,17 @@ describe('Ecomm tests', () => {
     results: [refund]
   }
 
+  const create_refund_payload = {
+    reason: "string",
+    notify_customer: true,
+    items: [
+      {
+        id: "string",
+        quantity: 0
+      }
+    ]
+  }
+
   const fulfillment = {
     id: "fulfil_test",
     status: "FULFILLED",
@@ -1271,9 +1282,28 @@ describe('Ecomm tests', () => {
     return await duda.ecomm.orders.update({ site_name, order_id, status: 'IN_PROGRESS', ...update_order_payload })
   })
 
-  it('can list all refunds', async () => {
+  it('can list all refunds (DEPRECATED)', async () => {
     scope.get(`/api/sites/multiscreen/${site_name}/ecommerce/orders/${order_id}/refunds?offset=${offset}&limit=${limit}&sort=${sort}&direction=${direction}`).reply(200, list_refunds)
     return await duda.ecomm.orders.listRefund({
+      site_name,
+      order_id,
+      offset,
+      limit,
+      sort,
+      direction
+    }).then(res => expect(res).to.eql(list_refunds))
+  })
+
+  it('can get a specific refund (DEPRECATED)', async () => {
+    scope.get(`/api/sites/multiscreen/${site_name}/ecommerce/orders/${order_id}/refunds/${refund_id}`).reply(200, refund)
+
+    return await duda.ecomm.orders.getRefund({ site_name, order_id, refund_id })
+      .then(res => expect(res).to.eql({ ...refund }))
+  })
+
+  it('can list all refunds', async () => {
+    scope.get(`/api/sites/multiscreen/${site_name}/ecommerce/orders/${order_id}/refunds?offset=${offset}&limit=${limit}&sort=${sort}&direction=${direction}`).reply(200, list_refunds)
+    return await duda.ecomm.orders.refunds.list({
       site_name,
       order_id,
       offset,
@@ -1286,27 +1316,17 @@ describe('Ecomm tests', () => {
   it('can get a specific refund', async () => {
     scope.get(`/api/sites/multiscreen/${site_name}/ecommerce/orders/${order_id}/refunds/${refund_id}`).reply(200, refund)
 
-    return await duda.ecomm.orders.getRefund({ site_name, order_id, refund_id })
-      .then(res => expect(res).to.eql({ ...refund }))
-  })
-
-  it('can list all refunds (alternate)', async () => {
-    scope.get(`/api/sites/multiscreen/${site_name}/ecommerce/orders/${order_id}/refunds?offset=${offset}&limit=${limit}&sort=${sort}&direction=${direction}`).reply(200, list_refunds)
-    return await duda.ecomm.orders.refunds.list({
-      site_name,
-      order_id,
-      offset,
-      limit,
-      sort,
-      direction
-    }).then(res => expect(res).to.eql(list_refunds))
-  })
-
-  it('can get a specific refund (alternate)', async () => {
-    scope.get(`/api/sites/multiscreen/${site_name}/ecommerce/orders/${order_id}/refunds/${refund_id}`).reply(200, refund)
-
     return await duda.ecomm.orders.refunds.get({ site_name, order_id, refund_id })
       .then(res => expect(res).to.eql({ ...refund }))
+  })
+
+  it('can create a refund', async () => {
+    scope.post(`/api/sites/multiscreen/${site_name}/ecommerce/orders/${order_id}/refunds`, (body) => {
+      expect(body).to.eql({ ...create_refund_payload })
+      return body
+    }).reply(201, refund)
+
+    return await duda.ecomm.orders.refunds.create({ site_name, order_id, ...create_refund_payload })
   })
 
   it('can list all order fulfillments', async () => {

--- a/tests/page.tests.ts
+++ b/tests/page.tests.ts
@@ -66,6 +66,26 @@ describe('Page tests', () => {
         parent_element_id: "element_id"
     }
 
+    const footer_element = {
+        element_id: element_id,
+        next_sibling_id: "next_sibling_id",
+        element_source_id: "element_source_id"
+    }
+
+    const list_footer_elements_response = {
+        results: [footer_element]
+    }
+
+    const create_footer_element_payload = {
+        element_source_id: "element_source_id",
+        next_sibling_id: "next_sibling_id"
+    }
+
+    const update_footer_page_element_payload = {
+        next_sibling_id: "next_sibling_id",
+        parent_element_id: "element_id"
+    }
+
     before(() => {
         duda = new Duda({
           user: 'testuser',
@@ -129,10 +149,7 @@ describe('Page tests', () => {
     describe('Page Elements', () => {
         it('can list all page elements on a site for a page', async () => {
             scope.get(`${api_path}${site_name}${api_segment}/${page_uuid}/elements`).reply(200, list_page_elements_response)
-            return await duda.pages.elements.list({
-                site_name: site_name,
-                page_uuid: page_uuid
-            })
+            return await duda.pages.elements.list({ site_name, page_uuid })
         })
 
         it('can create a page element', async () => {
@@ -140,14 +157,7 @@ describe('Page tests', () => {
                 expect(body).to.eql(create_page_element_payload)
                 return body
             }).reply(200, page_element)
-            return await duda.pages.elements.create({
-              site_name: site_name,
-              page_uuid: page_uuid,
-              element_source_id: "element_source_id",
-              type: "SECTION",
-              next_sibling_id: "next_sibling_id",
-              parent_element_id: "element_id"
-            })
+            return await duda.pages.elements.create({ site_name, page_uuid, ...create_page_element_payload })
         })
     
         it('can update a page element by id', async () => {
@@ -156,22 +166,44 @@ describe('Page tests', () => {
                 return body
             }).reply(200, response)
             return await duda.pages.elements.update({
-                site_name: site_name,
-                page_uuid: page_uuid,
-                element_id: element_id,
-                type: "SECTION",
-                next_sibling_id: "next_sibling_id",
-                parent_element_id: "element_id"
+                site_name,
+                page_uuid,
+                element_id,
+                ...update_page_element_payload
             })
         })
     
         it('can delete a page by id', async () => {
             scope.delete(`${api_path}${site_name}${api_segment}/${page_uuid}/elements/${element_id}`).reply(204)
-            return await duda.pages.elements.delete({
-                site_name: site_name,
-                page_uuid: page_uuid,
-                element_id: element_id
-            })
+            return await duda.pages.elements.delete({ site_name, page_uuid, element_id })
+        })
+      })
+
+    describe('Footer Page Elements', () => {
+        it('can list all footer page elements on a site for a page', async () => {
+            scope.get(`${api_path}${site_name}/footer/elements`).reply(200, list_footer_elements_response)
+            return await duda.pages.footer.list({ site_name })
+        })
+
+        it('can create a footer page element', async () => {
+            scope.post(`${api_path}${site_name}/footer/elements`, (body) => {
+                expect(body).to.eql(create_footer_element_payload)
+                return body
+            }).reply(201, footer_element)
+            return await duda.pages.footer.create({ site_name, ...create_footer_element_payload })
+        })
+    
+        it('can update a footer page element by id', async () => {
+            scope.put(`${api_path}${site_name}/footer/elements/${element_id}`, (body) => {
+                expect(body).to.eql(update_footer_page_element_payload)
+                return body
+            }).reply(200, response)
+            return await duda.pages.footer.update({ site_name, element_id, ...update_footer_page_element_payload })
+        })
+    
+        it('can delete a page by id', async () => {
+            scope.delete(`${api_path}${site_name}/footer/elements/${element_id}`).reply(204)
+            return await duda.pages.footer.delete({ site_name ,element_id })
         })
       })
 })


### PR DESCRIPTION
Updated Refund Endpoints
- Added Create Refund Endpoint to partner and app side
- Added appropriate tests
- Updated README to include the new endpoint
- Updated the List and Get Refund(s) Endpoints so the path is more correct
- Updated README and tests to reflect these new changes

Footer Page Element Endpoints
- Added Footer Page Element Endpoints to partner side
- Updated types file appropriately
- Added new tests for endpoints
- Updated some old page element tests
- Updated README to include new endpoints