### PR TITLE
Product Options Choices/Cancel Order/Blog Endpoint(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1760,7 +1760,7 @@ duda.ecomm.options.update({
 duda.ecomm.options.delete({ site_name: site_name, option_id: option_id });
 ```
 
-## Create Product Option Choice
+## Create Product Option Choice (DEPRECATED -- See updated method [here](#create-product-option-choice))
 
 [Create Product Option Choice Reference](https://developer.duda.co/reference/ecommerce-create-product-option-choice)
 
@@ -1776,6 +1776,55 @@ duda.ecomm.options.createChoice({
 });
 ```
 
+## Update Product Option Choice (DEPRECATED -- See updated method [here](#update-product-option-choice))
+
+[Update Product Option Choice Reference](https://developer.duda.co/reference/ecommerce-update-product-option-choice)
+
+### Request
+
+`PUT https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/options/{option_id}/choices/{choice_id}`
+
+```typescript
+duda.ecomm.options.updateChoice({
+  site_name: site_name,
+  option_id: option_id,
+  choice_id: choice_id,
+  value: value,
+});
+```
+
+## Delete Product Option Choice (DEPRECATED -- See updated method [here](#delete-product-option-choice))
+
+[Delete Product Option Choice Reference](https://developer.duda.co/reference/ecommerce-delete-product-option-choice)
+
+### Request
+
+`DELETE https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/options/{option_id}/choices/{choice_id}`
+
+```typescript
+duda.ecomm.options.deleteChoice({
+  site_name: site_name,
+  option_id: option_id,
+  choice_id: choice_id,
+});
+```
+
+## Create Product Option Choice
+
+[Create Product Option Choice Reference](https://developer.duda.co/reference/ecommerce-create-product-option-choice)
+
+### Request
+
+`POST https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/options/{option_id}/choices`
+
+```typescript
+duda.ecomm.options.choices.create({
+  site_name: site_name,
+  option_id: option_id,
+  value: value,
+});
+```
+
 ## Update Product Option Choice
 
 [Update Product Option Choice Reference](https://developer.duda.co/reference/ecommerce-update-product-option-choice)
@@ -1785,7 +1834,7 @@ duda.ecomm.options.createChoice({
 `PUT https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/options/{option_id}/choices/{choice_id}`
 
 ```typescript
-duda.ecomm.options.createChoice({
+duda.ecomm.options.choices.update({
   site_name: site_name,
   option_id: option_id,
   choice_id: choice_id,
@@ -1802,7 +1851,7 @@ duda.ecomm.options.createChoice({
 `DELETE https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/options/{option_id}/choices/{choice_id}`
 
 ```typescript
-duda.ecomm.options.createChoice({
+duda.ecomm.options.choices.delete({
   site_name: site_name,
   option_id: option_id,
   choice_id: choice_id,
@@ -3379,7 +3428,7 @@ duda.appstore.ecomm.options.delete({
 });
 ```
 
-## Create Product Option Choice
+## Create Product Option Choice (DEPRECATED -- See updated method [here](#create-product-option-choice-1))
 
 [Create Product Option Choice Reference](https://developer.duda.co/reference/app-ecommerce-create-product-option)
 
@@ -3395,6 +3444,55 @@ duda.appstore.ecomm.options.createChoice({
 });
 ```
 
+## Update Product Option Choice (DEPRECATED -- See updated method [here](#update-product-option-choice-1))
+
+[Update Product Option Choice Reference](https://developer.duda.co/reference/app-ecommerce-update-product-option-choice)
+
+### Request
+
+`PUT https://api-sandbox.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/options/{option_id}/choices/{choice_id}`
+
+```typescript
+duda.appstore.ecomm.options.updateChoice({
+  site_name: site_name,
+  option_id: option_id,
+  choice_id: choice_id,
+  value: value,
+});
+```
+
+## Delete Product Option Choice (DEPRECATED -- See updated method [here](#delete-product-option-choice-1))
+
+[Delete Product Option Choice Reference](https://developer.duda.co/reference/app-ecommerce-delete-product-option-choice)
+
+### Request
+
+`DELETE https://api-sandbox.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/options/{option_id}/choices/{choice_id}`
+
+```typescript
+duda.appstore.ecomm.options.deleteChoice({
+  site_name: site_name,
+  option_id: option_id,
+  choice_id: choice_id,
+});
+```
+
+## Create Product Option Choice
+
+[Create Product Option Choice Reference](https://developer.duda.co/reference/app-ecommerce-create-product-option)
+
+### Request
+
+`POST https://api-sandbox.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/options/{option_id}/choices`
+
+```typescript
+duda.appstore.ecomm.options.choices.create({
+  site_name: site_name,
+  option_id: option_id,
+  value: value,
+});
+```
+
 ## Update Product Option Choice
 
 [Update Product Option Choice Reference](https://developer.duda.co/reference/app-ecommerce-update-product-option-choice)
@@ -3404,7 +3502,7 @@ duda.appstore.ecomm.options.createChoice({
 `PUT https://api-sandbox.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/options/{option_id}/choices/{choice_id}`
 
 ```typescript
-duda.appstore.ecomm.options.createChoice({
+duda.appstore.ecomm.options.choices.update({
   site_name: site_name,
   option_id: option_id,
   choice_id: choice_id,
@@ -3421,7 +3519,7 @@ duda.appstore.ecomm.options.createChoice({
 `DELETE https://api-sandbox.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/options/{option_id}/choices/{choice_id}`
 
 ```typescript
-duda.appstore.ecomm.options.createChoice({
+duda.appstore.ecomm.options.choices.delete({
   site_name: site_name,
   option_id: option_id,
   choice_id: choice_id,

--- a/README.md
+++ b/README.md
@@ -1238,6 +1238,18 @@ duda.ecomm.orders.create({ site_name: site_name });
 duda.ecomm.orders.update({ site_name: site_name, order_id: order_id });
 ```
 
+## Cancel Order
+
+[Cancel Order Reference](https://developer.duda.co/reference/ecommerce-cancel-order#/)
+
+### Request
+
+`POST https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/cancel`
+
+```typescript
+duda.ecomm.orders.cancel({ site_name: site_name, order_id: order_id });
+```
+
 ## List Refunds (DEPRECATED -- See updated method [here](#list-refunds))
 
 [List Refunds Reference](https://developer.duda.co/reference/list-refunds)
@@ -3574,6 +3586,18 @@ duda.appstore.ecomm.orders.create({ site_name: site_name });
 
 ```typescript
 duda.appstore.ecomm.orders.update({ site_name: site_name, order_id: order_id });
+```
+
+## Cancel Order
+
+[Cancel Order Reference](https://developer.duda.co/reference/app-ecomm-cancel-order#/)
+
+### Request
+
+`POST https://api-sandbox.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/orders/{order_id}/cancel`
+
+```typescript
+duda.appstore.ecomm.orders.cancel({ site_name: site_name, order_id: order_id });
 ```
 
 ## List Refunds (DEPRECATED -- See updated method [here](#list-refunds-1))

--- a/src/lib/apps/ecomm/Choices.ts
+++ b/src/lib/apps/ecomm/Choices.ts
@@ -1,0 +1,58 @@
+import * as Types from './types';
+import { SubResource } from '../../base';
+import { APIEndpoint } from '../../APIEndpoint';
+import { TokenRequest } from '../types';
+
+class AppsChoices extends SubResource {
+  create = APIEndpoint<TokenRequest<Types.CreateOptionChoicePayload>,
+  Types.CreateOptionChoiceResponse>({
+    method: 'post',
+    path: '/site/{site_name}/ecommerce/options/{option_id}/choices',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    bodyParams: {
+      value: {
+        type: 'string',
+        required: true,
+      },
+    },
+  });
+
+  update = APIEndpoint<TokenRequest<Types.UpdateOptionChoicePayload>,
+  Types.UpdateOptionChoiceResponse>({
+    method: 'put',
+    path: '/site/{site_name}/ecommerce/options/{option_id}/choices/{choice_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+    bodyParams: {
+      value: {
+        type: 'string',
+        required: true,
+      },
+    },
+  });
+
+  delete = APIEndpoint<TokenRequest<Types.DeleteOptionChoicePayload>,
+  Types.DeleteOptionChoiceResponse>({
+    method: 'delete',
+    path: '/site/{site_name}/ecommerce/options/{option_id}/choices/{choice_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+}
+
+export default AppsChoices;
+export { AppsChoices };

--- a/src/lib/apps/ecomm/Options.ts
+++ b/src/lib/apps/ecomm/Options.ts
@@ -2,8 +2,11 @@ import * as Types from './types';
 import { SubResource } from '../../base';
 import { APIEndpoint } from '../../APIEndpoint';
 import { TokenRequest } from '../types';
+import AppsChoices from './Choices';
 
 class AppsOptions extends SubResource {
+  choices = new AppsChoices(this.base);
+
   list = APIEndpoint<TokenRequest<Types.ListOptionsPayload>, Types.ListOptionsResponse>({
     method: 'get',
     path: '/site/{site_name}/ecommerce/options',

--- a/src/lib/apps/ecomm/Orders.ts
+++ b/src/lib/apps/ecomm/Orders.ts
@@ -80,6 +80,19 @@ class AppsOrders extends SubResource {
     },
   });
 
+  cancel = APIEndpoint<TokenRequest<Types.CancelOrderPayload>, Types.CancelOrderResponse>({
+    method: 'patch',
+    path: '/site/{site_name}/ecommerce/orders/{order_id}/cancel',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
   listRefund = APIEndpoint<TokenRequest<Types.ListRefundsPayload>, Types.ListRefundsResponse>({
     method: 'get',
     path: '/site/{site_name}/ecommerce/orders/{order_id}/refunds',

--- a/src/lib/blog/types.ts
+++ b/src/lib/blog/types.ts
@@ -50,7 +50,8 @@ export interface UpdateBlogPostPayload {
     path?: string,
     publish_date?: string,
     tags?: Array<string>,
-    title?: string
+    title?: string,
+    schedule_publish_date?: string
 }
 
 export interface BlogPost {
@@ -64,7 +65,8 @@ export interface BlogPost {
     publish_date?: string,
     status?: string,
     tags?: Array<string>,
-    title?: string
+    title?: string,
+    schedule_publish_date?: string
 }
 
 export interface MainImage {

--- a/src/lib/ecomm/Choices.ts
+++ b/src/lib/ecomm/Choices.ts
@@ -1,0 +1,44 @@
+import * as Types from './types';
+import Resource from '../base';
+import { APIEndpoint } from '../APIEndpoint';
+
+class Choices extends Resource {
+  create = APIEndpoint<Types.CreateOptionChoicePayload, Types.CreateOptionChoiceResponse>({
+    method: 'post',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/options/{option_id}/choices',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    bodyParams: {
+      value: {
+        type: 'string',
+        required: true,
+      },
+    },
+  });
+
+  update = APIEndpoint<Types.UpdateOptionChoicePayload, Types.UpdateOptionChoiceResponse>({
+    method: 'put',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/options/{option_id}/choices/{choice_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    bodyParams: {
+      value: {
+        type: 'string',
+        required: true,
+      },
+    },
+  });
+
+  delete = APIEndpoint<Types.DeleteOptionChoicePayload, Types.DeleteOptionChoiceResponse>({
+    method: 'delete',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/options/{option_id}/choices/{choice_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+}
+
+export default Choices;
+export { Choices };

--- a/src/lib/ecomm/Options.ts
+++ b/src/lib/ecomm/Options.ts
@@ -1,8 +1,11 @@
 import * as Types from './types';
 import Resource from '../base';
+import Choices from './Choices';
 import { APIEndpoint } from '../APIEndpoint';
 
 class Options extends Resource {
+  choices = new Choices(this.config);
+
   list = APIEndpoint<Types.ListOptionsPayload, Types.ListOptionsResponse>({
     method: 'get',
     path: '/api/sites/multiscreen/{site_name}/ecommerce/options',

--- a/src/lib/ecomm/Orders.ts
+++ b/src/lib/ecomm/Orders.ts
@@ -59,6 +59,14 @@ class Orders extends Resource {
     },
   });
 
+  cancel = APIEndpoint<Types.CancelOrderPayload, Types.CancelOrderResponse>({
+    method: 'post',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/cancel',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
   listRefund = APIEndpoint<Types.ListRefundsPayload, Types.ListRefundsResponse>({
     method: 'get',
     path: '/api/sites/multiscreen/{site_name}/ecommerce/orders/{order_id}/refunds',

--- a/src/lib/ecomm/types.ts
+++ b/src/lib/ecomm/types.ts
@@ -471,6 +471,16 @@ export interface UpdateOrderPayload {
 
 export interface UpdateOrderResponse extends Order {}
 
+export interface CancelOrderPayload {
+  site_name: string,
+  order_id: string,
+  reason?: string,
+  restock_items?: boolean,
+  refund?: boolean
+}
+
+export interface CancelOrderResponse extends Order {}
+
 export interface ListRefundsPayload {
   site_name: string,
   order_id: string,

--- a/tests/app/ecomm.tests.ts
+++ b/tests/app/ecomm.tests.ts
@@ -425,6 +425,12 @@ describe('App store ecomm tests', () => {
     metadata: "string"
   }
 
+  const cancel_order_payload = {
+    reason: "string",
+    restock_items: true,
+    refund: true
+  }
+
   const payment_session = {
     id: "string",
     mode: "LIVE",
@@ -1014,6 +1020,15 @@ describe('App store ecomm tests', () => {
     }).reply(200, order)
 
     return await duda.appstore.ecomm.orders.update({ site_name, order_id, token, status: 'IN_PROGRESS', ...update_order_payload })
+  })
+
+  it('can cancel an order', async () => {
+    scope.patch(`${base_path}/site/${site_name}/ecommerce/orders/${order_id}/cancel`, (body) => {
+      expect(body).to.eql({ ...cancel_order_payload })
+      return body
+    }).reply(200, order)
+
+    return await duda.appstore.ecomm.orders.cancel({ site_name, order_id, token, ...cancel_order_payload })
   })
 
   it('can list all refunds (DEPRECATED)', async () => {

--- a/tests/app/ecomm.tests.ts
+++ b/tests/app/ecomm.tests.ts
@@ -933,7 +933,7 @@ describe('App store ecomm tests', () => {
     return await duda.appstore.ecomm.options.delete({ site_name, option_id, token })
   })
 
-  it('can create a product option choice', async () => {
+  it('can create a product option choice (DEPRECATED)', async () => {
     scope.post(`${base_path}/site/${site_name}/ecommerce/options/${option_id}/choices`, (body) => {
       expect(body).to.eql({ value: 'string' })
       return body
@@ -942,7 +942,7 @@ describe('App store ecomm tests', () => {
     return await duda.appstore.ecomm.options.createChoice({ site_name, option_id, token, value: 'string' })
   })
 
-  it('can update a product option choice', async () => {
+  it('can update a product option choice (DEPRECATED)', async () => {
     scope.put(`${base_path}/site/${site_name}/ecommerce/options/${option_id}/choices/${choice_id}`, (body) => {
       expect(body).to.eql({ value: 'string' })
       return body
@@ -951,9 +951,32 @@ describe('App store ecomm tests', () => {
     return await duda.appstore.ecomm.options.updateChoice({ site_name, option_id, choice_id, token, value: 'string' })
   })
 
-  it('can delete a product option choice', async () => {
+  it('can delete a product option choice (DEPRECATED)', async () => {
     scope.delete(`${base_path}/site/${site_name}/ecommerce/options/${option_id}/choices/${choice_id}`).reply(204)
     return await duda.appstore.ecomm.options.deleteChoice({ site_name, option_id, choice_id, token })
+  })
+
+  it('can create a product option choice', async () => {
+    scope.post(`${base_path}/site/${site_name}/ecommerce/options/${option_id}/choices`, (body) => {
+      expect(body).to.eql({ value: 'string' })
+      return body
+    }).reply(200, product_option)
+
+    return await duda.appstore.ecomm.options.choices.create({ site_name, option_id, token, value: 'string' })
+  })
+
+  it('can update a product option choice', async () => {
+    scope.put(`${base_path}/site/${site_name}/ecommerce/options/${option_id}/choices/${choice_id}`, (body) => {
+      expect(body).to.eql({ value: 'string' })
+      return body
+    }).reply(200, product_option)
+
+    return await duda.appstore.ecomm.options.choices.update({ site_name, option_id, choice_id, token, value: 'string' })
+  })
+
+  it('can delete a product option choice', async () => {
+    scope.delete(`${base_path}/site/${site_name}/ecommerce/options/${option_id}/choices/${choice_id}`).reply(204)
+    return await duda.appstore.ecomm.options.choices.delete({ site_name, option_id, choice_id, token })
   })
 
   it('can list all orders', async () => {

--- a/tests/blog.tests.ts.ts
+++ b/tests/blog.tests.ts.ts
@@ -35,7 +35,8 @@ describe('Blog tests', () => {
     path: "string",
     publish_date: "string",
     tags: ["string"],
-    title: "string"
+    title: "string",
+    schedule_publish_date: "string"
   }
 
   const blog_post = {
@@ -47,6 +48,7 @@ describe('Blog tests', () => {
     no_index: true,
     path: "string",
     publish_date: "string",
+    schedule_publish_date: "string",
     status: "string",
     tags: ["string"],
     title: "string",

--- a/tests/ecomm.tests.ts
+++ b/tests/ecomm.tests.ts
@@ -669,6 +669,12 @@ describe('Ecomm tests', () => {
     metadata: "string"
   }
 
+  const cancel_order_payload = {
+    reason: "string",
+    restock_items: true,
+    refund: true
+  }
+
   const refund = {
     id: "string",
     order_id,
@@ -1280,6 +1286,15 @@ describe('Ecomm tests', () => {
     }).reply(200, order)
 
     return await duda.ecomm.orders.update({ site_name, order_id, status: 'IN_PROGRESS', ...update_order_payload })
+  })
+
+  it('can cancel an order', async () => {
+    scope.post(`/api/sites/multiscreen/${site_name}/ecommerce/orders/${order_id}/cancel`, (body) => {
+      expect(body).to.eql({ ...cancel_order_payload })
+      return body
+    }).reply(200, order)
+
+    return await duda.ecomm.orders.cancel({ site_name, order_id, ...cancel_order_payload })
   })
 
   it('can list all refunds (DEPRECATED)', async () => {

--- a/tests/ecomm.tests.ts
+++ b/tests/ecomm.tests.ts
@@ -1500,7 +1500,7 @@ describe('Ecomm tests', () => {
     return await duda.ecomm.options.delete({ site_name, option_id })
   })
 
-  it('can create a product option choice', async () => {
+  it('can create a product option choice (DEPRECATED)', async () => {
     scope.post(`/api/sites/multiscreen/${site_name}/ecommerce/options/${option_id}/choices`, (body) => {
       expect(body).to.eql({ value: 'string' })
       return body
@@ -1509,7 +1509,7 @@ describe('Ecomm tests', () => {
     return await duda.ecomm.options.createChoice({ site_name, option_id, value: 'string' })
   })
 
-  it('can update a product option choice', async () => {
+  it('can update a product option choice (DEPRECATED)', async () => {
     scope.put(`/api/sites/multiscreen/${site_name}/ecommerce/options/${option_id}/choices/${choice_id}`, (body) => {
       expect(body).to.eql({ value: 'string' })
       return body
@@ -1518,9 +1518,32 @@ describe('Ecomm tests', () => {
     return await duda.ecomm.options.updateChoice({ site_name, option_id, choice_id, value: 'string' })
   })
 
-  it('can delete a product option choice', async () => {
+  it('can delete a product option choice (DEPRECATED)', async () => {
     scope.delete(`/api/sites/multiscreen/${site_name}/ecommerce/options/${option_id}/choices/${choice_id}`).reply(204)
     return await duda.ecomm.options.deleteChoice({ site_name, option_id, choice_id })
+  })
+
+  it('can create a product option choice', async () => {
+    scope.post(`/api/sites/multiscreen/${site_name}/ecommerce/options/${option_id}/choices`, (body) => {
+      expect(body).to.eql({ value: 'string' })
+      return body
+    }).reply(200, product_option)
+
+    return await duda.ecomm.options.choices.create({ site_name, option_id, value: 'string' })
+  })
+
+  it('can update a product option choice', async () => {
+    scope.put(`/api/sites/multiscreen/${site_name}/ecommerce/options/${option_id}/choices/${choice_id}`, (body) => {
+      expect(body).to.eql({ value: 'string' })
+      return body
+    }).reply(200, product_option)
+
+    return await duda.ecomm.options.choices.update({ site_name, option_id, choice_id, value: 'string' })
+  })
+
+  it('can delete a product option choice', async () => {
+    scope.delete(`/api/sites/multiscreen/${site_name}/ecommerce/options/${option_id}/choices/${choice_id}`).reply(204)
+    return await duda.ecomm.options.choices.delete({ site_name, option_id, choice_id })
   })
 
   it('can get a product variation', async () => {


### PR DESCRIPTION
Product Option Choices
- Updated product option choice endpoints to different path for consistency for partner and app side
- Deprecated old paths
- Updated tests appropriately
- Updated README appropriately

Cancel Order Endpoint
- Added Cancel Order endpoint for partner and app side
- Added appropriate tests
- Updated README accordingly

Blog Endpoint Update
- Added missing field to update payload, get/list responses
- Updated tests appropriately