### PR TITLE
Site Theme Endpoints, Async Tasks and List Templates Endpoint Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ duda.async.get({ task_id: task_id });
 `GET https://api.duda.co/api/sites/multiscreen/templates`
 
 ```typescript
-duda.templates.list();
+duda.templates.list({ 'page_count.gte': 1 });
 ```
 
 ## Get Template

--- a/README.md
+++ b/README.md
@@ -468,6 +468,32 @@ duda.sites.theme.get({ site_name: site_name });
 duda.sites.theme.update({ site_name: site_name });
 ```
 
+# Async Site Tasks
+
+## Generate Site with AI
+
+[Generate Site with AI Reference](https://developer.duda.co/reference/generate-site-with-ai#/)
+
+### Request
+
+`POST https://api.duda.co/api/async-tasks/generate-site-with-ai`
+
+```typescript
+duda.async.generate();
+```
+
+## Get Task
+
+[Get Task Reference](https://developer.duda.co/reference/get-task#/)
+
+### Request
+
+`GET https://api.duda.co/api/async-tasks/{task_id}`
+
+```typescript
+duda.async.get({ task_id: task_id });
+```
+
 # Templates
 
 ## List Templates

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import/prefer-default-export
 import {EventEmitter} from 'events';
 import Accounts from './lib/accounts/Accounts';
 import Apps, { DudaAppConfig } from './lib/apps/Apps';
+import Async from './lib/async tasks/Async';
 import Blog from './lib/blog/Blog';
 import Collections from './lib/collections/Collections';
 import Content from './lib/content/Content';
@@ -43,6 +44,8 @@ class Duda {
   accounts: Accounts;
 
   appstore: Apps;
+
+  async: Async;
 
   blog: Blog;
 
@@ -85,6 +88,7 @@ class Duda {
     // new:resource::hook
     this.appstore = new Apps(config, this.events, appOpts);
     this.accounts = new Accounts(config);
+    this.async = new Async(config);
     this.blog = new Blog(config);
     this.collections = new Collections(config);
     this.content = new Content(config);

--- a/src/lib/async tasks/Async.ts
+++ b/src/lib/async tasks/Async.ts
@@ -1,0 +1,26 @@
+import * as Types from './types';
+import Resource from '../base';
+
+import { APIEndpoint } from '../APIEndpoint';
+
+class Async extends Resource {
+
+  generate = APIEndpoint<Types.GenerateAsyncPayload, Types.GenerateAsyncResponse>({
+    method: 'post',
+    path: '/api/async-tasks/generate-site-with-ai',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  get = APIEndpoint<Types.GetAsyncPayload, Types.GetAsyncResponse>({
+    method: 'get',
+    path: '/api/async-tasks/{task_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+}
+
+export default Async;
+export { Async };

--- a/src/lib/async tasks/types.ts
+++ b/src/lib/async tasks/types.ts
@@ -1,0 +1,137 @@
+interface AdditionalAIContext {
+    max_pages?: number
+}
+
+interface BusinessData {
+    category: string,
+    data_controller?: string,
+    description: string,
+    logo_url?: string,
+    name: string,
+    service_area?: string,
+    tone_of_voice: string
+}
+
+interface Labels {
+    name?: string
+}
+
+interface SiteAlternateDomains {
+    domains?: Array<string>,
+    is_redirect?: boolean
+}
+
+interface SiteBusinessInfoAddress {
+    street?: string,
+    state?: string,
+    city?: string,
+    country?: string,
+    zip_code?: string
+}
+
+interface SiteBusinessInfo {
+    business_name?: string,
+    phone_number?: string,
+    email?: string,
+    address?: SiteBusinessInfoAddress
+}
+
+interface SiteSEO {
+    title?: string,
+    description?: string,
+    og_image?: string,
+    no_index?: boolean
+}
+
+interface SiteData {
+    external_uid?: string,
+    google_tracking_id?: string,
+    googletagmanager_container_id?: Array<string>,
+    site_alternate_domains?: SiteAlternateDomains,
+    site_business_info?: SiteBusinessInfo,
+    site_seo?: SiteSEO,
+    site_domain?: string
+}
+
+interface SiteThemeColor  {
+    id?: string,
+    value?: string,
+    label?: string,
+}
+
+interface BreakpointOverrides {
+    font_size?: string
+}
+
+interface ThemeBreakpoints {
+    mobile?: BreakpointOverrides,
+    tablet?: BreakpointOverrides
+}
+
+interface ThemeTextStyle {
+    breakpoints?: ThemeBreakpoints,
+    font_family?: string,
+    font_size?: string,
+    font_weight?: string,
+    color?: string,
+    line_height?: string,
+    letter_spacing?: string,
+    text_decoration?: string,
+    font_style?: string
+}
+
+interface ThemeTextStyles {
+    default?: ThemeTextStyle,
+    paragraph?: ThemeTextStyle,
+    h1?: ThemeTextStyle,
+    h2?: ThemeTextStyle,
+    h3?: ThemeTextStyle,
+    h4?: ThemeTextStyle,
+    h5?: ThemeTextStyle,
+    h6?: ThemeTextStyle
+}
+
+interface Theme {
+    colors?: Array<SiteThemeColor>,
+    text?: ThemeTextStyles
+}
+
+export interface GenerateAsyncPayload {
+    additional_ai_context?: AdditionalAIContext,
+    business_data?: BusinessData,
+    default_domain_prefix?: string,
+    do_not_gen_ssl?: boolean,
+    labels?: Array<Labels>,
+    lang?: string,
+    site_data?: SiteData,
+    theme?: Theme
+}
+
+export interface GenerateAsyncResponse {
+    id: string,
+    type: 'GENERATE_SITE_WITH_AI',
+    status: 'STARTED',
+    created_at: 'string'
+}
+
+export interface GetAsyncPayload {
+    task_id: string
+}
+
+interface GetAsyncSiteResult {
+    site_name: string
+}
+
+interface GetAsyncError {
+    message: string
+}
+
+export interface GetAsyncResponse {
+    id: string,
+    type: 'GENERATE_SITE_WITH_AI',
+    status: 'CREATED' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED',
+    result?: GetAsyncSiteResult,
+    error?: GetAsyncError,
+    created_at: string,
+    finished_at?: string
+}

--- a/src/lib/async tasks/types.ts
+++ b/src/lib/async tasks/types.ts
@@ -9,7 +9,7 @@ interface BusinessData {
     logo_url?: string,
     name: string,
     service_area?: string,
-    tone_of_voice: string
+    tone_of_voice?: string
 }
 
 interface Labels {

--- a/src/lib/sites/Theme.ts
+++ b/src/lib/sites/Theme.ts
@@ -19,12 +19,6 @@ class Theme extends Resource {
     defaults: {
       host: 'api.duda.co',
     },
-    bodyParams: {
-      colors: {
-        type: 'array',
-        required: true,
-      },
-    },
   });
 }
 

--- a/src/lib/sites/types.ts
+++ b/src/lib/sites/types.ts
@@ -132,6 +132,38 @@ export type SiteThemeColor = {
   label: string,
 }
 
+export interface BreakpointOverrides {
+  font_size?: string
+}
+
+export interface ThemeBreakpoints {
+  mobile?: BreakpointOverrides,
+  tablet?: BreakpointOverrides
+}
+
+export interface ThemeTextStyle {
+  font_family?: string;
+  font_size?: string;
+  font_weight?: string;
+  color?: string;
+  line_height?: string;
+  letter_spacing?: string;
+  text_decoration?: string;
+  font_style?: string;
+  breakpoints?: ThemeBreakpoints;
+}
+
+export interface ThemeTextStyles {
+  default?: ThemeTextStyle,
+  paragraph?: ThemeTextStyle,
+  h1?: ThemeTextStyle,
+  h2?: ThemeTextStyle,
+  h3?: ThemeTextStyle,
+  h4?: ThemeTextStyle,
+  h5?: ThemeTextStyle,
+  h6?: ThemeTextStyle
+}
+
 export interface SiteNamedPayload {
   site_name: string;
 }
@@ -143,6 +175,7 @@ export interface SiteNamedResponse {
 export interface UpdateSiteThemePayload {
   site_name: string,
   colors: Array<SiteThemeColor>,
+  text: ThemeTextStyles
 }
 
 export interface GetSiteResponse extends Site {
@@ -189,6 +222,7 @@ export type SwitchTemplateResponse = void;
 
 export type SiteThemeResponse = {
   colors: Array<SiteThemeColor>,
+  text: ThemeTextStyles
 }
 
 export interface PublishSitePayload extends SiteNamedPayload {
@@ -238,11 +272,18 @@ type AtLeastOne<T, U = {[K in keyof T]: Pick<T, K> }> = Partial<T> & U[keyof U]
 export type UpdateSitePayload = FirstPartialUpdateSitePayload
 & AtLeastOne<SecondPartialUpdateSitePayload>
 
+export type PublishStatus =
+  'NOT_PUBLISHED_YET' |
+  'PUBLISHED' |
+  'UNPUBLISHED';
+
 export interface ListSitePayload {
   offset?: number,
   limit?: number,
-  sort?: string,
-  direction?: 'asc' | 'desc'
+  sort?: 'CREATION_DATE' | 'LAST_PUBLISHED_DATE',
+  direction?: 'asc' | 'desc',
+  label_names?: Array<string>,
+  publish_status?: Array<PublishStatus>
 }
 
 export type GetSiteByNamePayload = {

--- a/src/lib/sites/types.ts
+++ b/src/lib/sites/types.ts
@@ -174,8 +174,8 @@ export interface SiteNamedResponse {
 
 export interface UpdateSiteThemePayload {
   site_name: string,
-  colors: Array<SiteThemeColor>,
-  text: ThemeTextStyles
+  colors?: Array<SiteThemeColor>,
+  text?: ThemeTextStyles
 }
 
 export interface GetSiteResponse extends Site {

--- a/src/lib/templates/Templates.ts
+++ b/src/lib/templates/Templates.ts
@@ -14,6 +14,42 @@ class Templates extends Resource {
         type: 'string',
         required: false,
       },
+      has_store: {
+        type: 'boolean',
+        required: false,
+      },
+      has_blog: {
+        type: 'boolean',
+        required: false,
+      },
+      store_type: {
+        type: 'string',
+        required: false,
+      },
+      editor: {
+        type: 'string',
+        required: false,
+      },
+      type: {
+        type: 'string',
+        required: false,
+      },
+      page_count: {
+        type: 'number',
+        required: false,
+      },
+      sort: {
+        type: 'string',
+        required: false,
+      },
+      direction: {
+        type: 'string',
+        required: false,
+      },
+      categories: {
+        type: 'string',
+        required: false,
+      },
     },
   });
 

--- a/src/lib/templates/Templates.ts
+++ b/src/lib/templates/Templates.ts
@@ -38,6 +38,18 @@ class Templates extends Resource {
         type: 'number',
         required: false,
       },
+      "page_count.gte": {
+        type: 'number',
+        required: false,
+      },
+      "page_count.lte": {
+        type: 'number',
+        required: false,
+      },
+      "name.contains": {
+        type: 'number',
+        required: false,
+      },
       sort: {
         type: 'string',
         required: false,

--- a/src/lib/templates/types.ts
+++ b/src/lib/templates/types.ts
@@ -30,6 +30,9 @@ export type ListTemplatesPayload = {
   editor?: 'ADVANCED' | 'ADVANCED-2.0',
   type?: 'DUDA' | 'CUSTOM',
   page_count?: number,
+  "page_count.gte"?: number,
+  "page_count.lte"?: number,
+  "name.contains"?: string,
   sort?: string,
   direction?: 'asc' | 'desc',
   categories?: string

--- a/src/lib/templates/types.ts
+++ b/src/lib/templates/types.ts
@@ -12,8 +12,10 @@ export interface Template {
   template_properties?: {
     can_build_from_url?: boolean,
     has_store?: boolean,
+    store_type?: 'NATIVE' | 'THIRDPARTY',
     has_blog?: boolean,
     page_count?: number
+    type?: 'DUDA' | 'CUSTOM'
   }
 }
 
@@ -21,7 +23,16 @@ export type ListTemplatesResponse = Array<Template>;
 export type GetTemplateResponse = Template;
 
 export type ListTemplatesPayload = {
-  lang?: string;
+  lang?: string,
+  has_store?: string,
+  has_blog?: string,
+  store_type?: 'NATIVE' | 'THIRDPARTY',
+  editor?: 'ADVANCED' | 'ADVANCED-2.0',
+  type?: 'DUDA' | 'CUSTOM',
+  page_count?: number,
+  sort?: string,
+  direction?: 'asc' | 'desc',
+  categories?: string
 }
 
 export interface CreateFromResponse {

--- a/tests/async.tests.ts
+++ b/tests/async.tests.ts
@@ -1,0 +1,149 @@
+import { expect } from "chai"
+import nock from "nock"
+import { Duda } from "../src/index"
+
+describe('Async Tasks tests', () => {
+  let duda: Duda;
+  let scope: nock.Scope;
+
+  const site_id = 'test_site';
+  const task_id = 'test_task';
+
+  const additional_ai_context = {
+    max_pages: 1
+  }
+
+  const business_data = {
+    category: 'string',
+    data_controller: 'string',
+    description: 'string',
+    logo_url: 'string',
+    name: 'string',
+    service_area: 'string',
+    tone_of_voice: 'string'
+  }
+
+  const labels = {
+    name: 'string'
+  }
+
+  const site_alternate_domains = {
+    domains: ['example2.org', 'example3.org'],
+    is_redirect: true
+  }
+
+  const site_business_info_address = {
+    street: 'Canon St',
+    state: 'CO',
+    city: 'Louisville',
+    country: 'US',
+    zip_code: '80027'
+  }
+
+  const site_business_info = {
+    business_name: 'My Business',
+    phone_number: '555-123-4567',
+    email: 'me@example.org',
+    address: site_business_info_address
+  }
+
+  const site_seo = {
+    og_image: 'https://example.org/path/to/image.png',
+    title: 'My Title',
+    description: 'My long description'
+  }
+
+  const site_data = {
+    external_uid: 'string',
+    google_tracking_id: 'string',
+    googletagmanager_container_id: ['string'],
+    site_alternate_domains: site_alternate_domains,
+    site_business_info: site_business_info,
+    site_seo: site_seo,
+    site_domain: 'example.org'
+  }
+
+  const colors_obj = {
+      id: "color_1",
+      value: "xffffff",
+      label: "test_label"
+  }
+
+  const theme_text = {
+      h1: {
+        font_family: "string",
+        font_size: "string",
+        font_weight: "string",
+        color: "string",
+        line_height: "string",
+        letter_spacing: "string",
+        text_decoration: "string",
+        font_style: "string",
+        breakpoints: {
+          mobile: {
+              font_size: "string"
+          }
+        }
+      }
+  }
+
+  const theme = {
+    colors: [colors_obj],
+    text: theme_text 
+  }
+
+  const generate_ai_site_payload = {
+    additional_ai_context: additional_ai_context,
+    business_data: business_data,
+    default_domain_prefix: 'string',
+    do_not_gen_ssl: true,
+    labels: [labels],
+    lang: 'en',
+    site_data: site_data,
+    theme: theme
+  }
+
+  const generate_ai_site_response = {
+    id: task_id,
+    type: 'GENERATE_SITE_WITH_AI',
+    status: 'STARTED',
+    created_at: 'string'
+  }
+
+  const get_async_task_response = {
+    id: task_id,
+    type: 'GENERATE_SITE_WITH_AI',
+    status: 'COMPLETED',
+    result: {
+      site_name: site_id
+    },
+    created_at: 'string',
+    finished_at: 'string'
+  }
+
+  before(() => {
+    duda = new Duda({
+      user: 'testuser',
+      pass: 'testpass',
+      env: Duda.Envs.direct
+    })
+
+    scope = nock('https://api.duda.co')
+  })
+
+  it('can generate a site with AI', async () => {
+    scope.post(`/api/async-tasks/generate-site-with-ai`, (body) => {
+      expect(body).to.eql({ ...generate_ai_site_payload })
+      return body
+    }).reply(200, generate_ai_site_response)
+
+    return await duda.async.generate({ ...generate_ai_site_payload })
+  })
+
+  it('can get an async task', async () => {
+    scope.get(`/api/async-tasks/${task_id}`).reply(200, get_async_task_response)
+
+    return await duda.async.get({ task_id })
+      .then(res => expect(res).to.eql({ ...get_async_task_response }))
+  })
+})

--- a/tests/site.tests.ts
+++ b/tests/site.tests.ts
@@ -51,6 +51,34 @@ describe('Site tests', () => {
     }
     const colors = [colors_obj]
 
+    const theme_text = {
+        h1: {
+          font_family: "string",
+          font_size: "string",
+          font_weight: "string",
+          color: "string",
+          line_height: "string",
+          letter_spacing: "string",
+          text_decoration: "string",
+          font_style: "string",
+          breakpoints: {
+            mobile: {
+                font_size: "string"
+            }
+          }
+        }
+    }
+
+    const site_theme_response = {
+        colors: colors,
+        text: theme_text
+    }
+
+    const update_site_theme_payload = {
+        colors: colors,
+        text: theme_text
+    }
+
     const create_response = { site_name: site_name };
     const get_response = {
         account_name: account_name,
@@ -89,12 +117,22 @@ describe('Site tests', () => {
         return await duda.sites.create({ ...site_obj })
     })
     it('can list all sites', async () => {
-        scope.get(`/api/sites/multiscreen`).reply(200, list_response)
-        return await duda.sites.list()
+        scope.get(`/api/sites/multiscreen?limit=0&offset=0&sort=CREATION_DATE&direction=asc`).reply(200, list_response)
+        return await duda.sites.list({
+            limit: 0,
+            offset: 0,
+            sort: 'CREATION_DATE',
+            direction: 'asc',
+            publish_status: [
+                'PUBLISHED'
+            ]
+        }).then(res => expect(res).to.eql(list_response))
     })
-    it('can get a site by name', async () => {
+    it('an get a site by name', async () => {
         scope.get(`${api_path}${site_name}`).reply(200, get_response)
-        return await duda.sites.get({ site_name:site_name })
+
+        return await duda.sites.get({ site_name })
+        .then(res => expect(res).to.eql({ ...get_response }))
     })
     it('can update a site', async () => {
         scope.post(`${api_path}update/${site_name}`, (body) => {
@@ -146,14 +184,16 @@ describe('Site tests', () => {
         return await duda.sites.delete({ site_name:site_name })
     })
     it('can get the site theme of a site', async () => {
-        scope.get(`${api_path}${site_name}/theme`).reply(200, get_response)
-        return await duda.sites.theme.get({ site_name:site_name })
+        scope.get(`${api_path}${site_name}/theme`).reply(200, site_theme_response)
+
+        return await duda.sites.theme.get({ site_name })
+        .then(res => expect(res).to.eql({ ...site_theme_response }))
     })
     it('can update the site theme of a site', async () => {
         scope.put(`${api_path}${site_name}/theme`, (body) => {
-            expect(body).to.eql({ colors: colors })
+            expect(body).to.eql({ ...update_site_theme_payload })
             return body
-        }).reply(200, colors)
-        return await duda.sites.theme.update({ site_name:site_name, colors: colors })
+        }).reply(200, site_theme_response)
+        return await duda.sites.theme.update({ site_name, ...update_site_theme_payload })
     })
 })

--- a/tests/template.tests.ts
+++ b/tests/template.tests.ts
@@ -39,8 +39,10 @@ describe('Template tests', () => {
   })
 
   it('can list all templates', async () => {
-    scope.get(`${api_path}`).reply(200, response)
-    return await duda.templates.list()
+    scope.get(`${api_path}?page_count.gte=5`).reply(200, response)
+    return await duda.templates.list({
+      'page_count.gte': 5
+    })
   })
 
   it('can list all templates of a specific language', async () => {


### PR DESCRIPTION
**Site Theme Endpoints**
- Updated Payloads/Responses for Get/Update Site Theme Endpoints
- Updated tests for those endpoints appropriately
- Updated type/test for List and Get Site(s) Endpoints

**Async Tasks and List Templates Endpoint Updates**
- Added new Async Tasks endpoints
	- Includes Generate Site with AI Endpoints
	- Includes Get Task Endpoint
- Added appropriate async tasks tests file
- Added new Endpoints to README
- Updated List Templates Endpoint to allow filtering with query params