### PR TITLE
Adding missing social account to Location Data Object

### DIFF
--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -32,6 +32,9 @@ export interface SocialAccounts {
   reddit?: string;
   tripadvisor?: string;
   snapchat?: string;
+  tiktok?: string;
+  whatsapp?: string;
+  google_my_business?: string;
 }
 
 export interface Address {


### PR DESCRIPTION
- added missing tiktok, whatsapp, google_my_business socials to object according to [docs](https://developer.duda.co/reference/site-content-content-library-object#social_accounts)