### PR TITLE
Booking Appointment Management Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -2044,6 +2044,78 @@ duda.ecomm.custom_fields.delete({ site_name: site_name, custom_field_id: custom_
 duda.booking.appointments.list({ site_name: site_name });
 ```
 
+## Book Appointment
+
+[Book Appointment Reference](https://developer.duda.co/reference/booking-appointments-create-booking-appointment)
+
+### Request
+
+`POST https://api.duda.co/api/sites/multiscreen/{site_name}/booking/appointments`
+
+```typescript
+duda.booking.appointments.book({ site_name: site_name, appointment_type_id: appointment_type_id, attendee: attendee, start: start });
+```
+
+## Cancel Booking Appointment
+
+[Cancel Booking Appointment Reference](https://developer.duda.co/reference/booking-appointments-cancel-booking-appointment)
+
+### Request
+
+`POST https://api.duda.co/api/sites/multiscreen/{site_name}/booking/appointments/{appointment_uid}/cancel`
+
+```typescript
+duda.booking.appointments.cancel({ site_name: site_name, appointment_uid: appointment_uid });
+```
+
+## Confirm Booking Appointment
+
+[Confirm Booking Appointment Reference](https://developer.duda.co/reference/booking-appointments-confirm-booking-appointment)
+
+### Request
+
+`POST https://api.duda.co/api/sites/multiscreen/{site_name}/booking/appointments/{appointment_uid}/confirm`
+
+```typescript
+duda.booking.appointments.confirm({ site_name: site_name, appointment_uid: appointment_uid });
+```
+
+## Get Booking Appointment Manage Links
+
+[Get Booking Appointment Manage Links Reference](https://developer.duda.co/reference/booking-appointments-get-manage-links)
+
+### Request
+
+`GET https://api.duda.co/api/sites/multiscreen/{site_name}/booking/appointments/{appointment_uid}/manage-links`
+
+```typescript
+duda.booking.appointments.getManageLinks({ site_name: site_name, appointment_uid: appointment_uid });
+```
+
+## Send Booking Appointment Management Email
+
+[Send Booking Appointment Management Email Reference](https://developer.duda.co/reference/booking-appointments-send-management-email)
+
+### Request
+
+`POST https://api.duda.co/api/sites/multiscreen/{site_name}/booking/appointments/{appointment_uid}/send-management-email`
+
+```typescript
+duda.booking.appointments.sendManagementEmail({ site_name: site_name, appointment_uid: appointment_uid });
+```
+
+## Reschedule Booking Appointment
+
+[Reschedule Booking Appointment Reference](https://developer.duda.co/reference/booking-appointments-reschedule-booking-appointment)
+
+### Request
+
+`POST https://api.duda.co/api/sites/multiscreen/{site_name}/booking/appointments/{appointment_uid}/reschedule`
+
+```typescript
+duda.booking.appointments.reschedule({ site_name: site_name, appointment_uid: appointment_uid, start: start });
+```
+
 # Booking Appointment Types
 
 ## List Booking Appointment Types

--- a/src/lib/booking/Appointments.ts
+++ b/src/lib/booking/Appointments.ts
@@ -56,6 +56,60 @@ class Appointments extends Resource {
       },
     },
   });
+
+  book = APIEndpoint<Types.BookAppointmentPayload, Types.BookAppointmentResponse>({
+    method: 'post',
+    path: '/api/sites/multiscreen/{site_name}/booking/appointments',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  cancel = APIEndpoint<Types.CancelBookingAppointmentPayload, Types.CancelBookingAppointmentResponse>({
+    method: 'post',
+    path: '/api/sites/multiscreen/{site_name}/booking/appointments/{appointment_uid}/cancel',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  confirm = APIEndpoint<Types.ConfirmBookingAppointmentPayload, Types.ConfirmBookingAppointmentResponse>({
+    method: 'post',
+    path: '/api/sites/multiscreen/{site_name}/booking/appointments/{appointment_uid}/confirm',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  getManageLinks = APIEndpoint<Types.GetAppointmentManageLinksPayload, Types.GetAppointmentManageLinksResponse>({
+    method: 'get',
+    path: '/api/sites/multiscreen/{site_name}/booking/appointments/{appointment_uid}/manage-links',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    queryParams: {
+      lang: {
+        type: 'string',
+        required: false,
+      },
+    },
+  });
+
+  reschedule = APIEndpoint<Types.RescheduleBookingAppointmentPayload, Types.RescheduleBookingAppointmentResponse>({
+    method: 'post',
+    path: '/api/sites/multiscreen/{site_name}/booking/appointments/{appointment_uid}/reschedule',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  sendManagementEmail = APIEndpoint<Types.SendAppointmentManagementEmailPayload, Types.SendAppointmentManagementEmailResponse>({
+    method: 'post',
+    path: '/api/sites/multiscreen/{site_name}/booking/appointments/{appointment_uid}/send-management-email',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
 }
 
 export default Appointments;

--- a/src/lib/booking/types.ts
+++ b/src/lib/booking/types.ts
@@ -49,8 +49,15 @@ type AppointmentAttendeesLanguage =
     'ca' |
     string;
 
+interface BookingFieldsResponses {
+    email?: string,
+    guests?: Array<string>,
+    name?: string
+}
+
 interface AppointmentAttendees {
     absent?: boolean,
+    booking_fields_responses?: BookingFieldsResponses,
     email?: string,
     language?: AppointmentAttendeesLanguage,
     name?: string,
@@ -62,15 +69,17 @@ interface AppointmentAttendees {
     }
 }
 
-interface BookingFieldsResponses {
+interface AppointmentAttendee {
     email?: string,
-    guests?: Array<string>,
-    name?: string
+    language?: AppointmentAttendeesLanguage,
+    name: string,
+    phone_number?: string,
+    time_zone: string,
 }
 
 interface BookingAppointmentHosts {
     email?: string,
-    id?: string,
+    id?: number,
     name?: string,
     time_zone?: string,
     username?: string
@@ -86,7 +95,7 @@ type BookingAppointmentStatus =
 export interface BookingAppointment {
     absent_host?: boolean,
     appointment_type?: AppointmentType,
-    attendees?: AppointmentAttendees,
+    attendees?: Array<AppointmentAttendees>,
     booking_fields_responses?: BookingFieldsResponses,
     cancellation_reason?: string,
     cancelled_by_email?: string,
@@ -94,10 +103,13 @@ export interface BookingAppointment {
     description?: string,
     duration?: number,
     end?: string,
-    hosts?: BookingAppointmentHosts,
+    hosts?: Array<BookingAppointmentHosts>,
     ics_uid?: string,
     id?: number,
     location?: string,
+    metadata?: {
+        [key: string]: string
+    },
     rating?: number,
     recurring_booking_uid?: string,
     rescheduled_by_email?: string,
@@ -109,7 +121,6 @@ export interface BookingAppointment {
     uid?: string,
     updated_at?: string
 }
-
 export interface ListBookingAppointmentsPayload {
     site_name: string,
     limit?: number,
@@ -131,6 +142,57 @@ export interface ListBookingAppointmentsResponse {
     results: Array<BookingAppointment>,
     site_name: string,
     total_responses: number
+}
+
+export interface  BookAppointmentPayload {
+    site_name: string,
+    appointment_type_id: string,
+    attendee: AppointmentAttendee,
+    booking_fields_responses?: BookingFieldsResponses,
+    duration?: number,
+    guests?: Array<string>,
+    metadata?: {
+        [key: string]: string
+    }
+    start: string,
+}
+
+export interface BookAppointmentResponse extends BookingAppointment {}
+
+export interface ManageAppointmentPayload {
+    site_name: string,
+    appointment_uid: string,
+}
+export interface CancelBookingAppointmentPayload extends ManageAppointmentPayload {
+    cancellation_reason?: string
+}
+
+export interface GetAppointmentManageLinksPayload extends ManageAppointmentPayload {
+    lang?: AppointmentAttendeesLanguage
+}
+
+export interface SendAppointmentManagementEmailPayload extends ManageAppointmentPayload {}
+
+export interface SendAppointmentManagementEmailResponse {
+    sent_to?: string,
+}
+
+export interface ConfirmBookingAppointmentPayload extends ManageAppointmentPayload {}
+
+export interface CancelBookingAppointmentResponse extends BookingAppointment {}
+
+export interface ConfirmBookingAppointmentResponse extends BookingAppointment {}
+
+export interface RescheduleBookingAppointmentPayload extends ManageAppointmentPayload {
+    rescheduling_reason?: string,
+    start: string,
+}
+
+export interface RescheduleBookingAppointmentResponse extends BookingAppointment {}
+
+export interface GetAppointmentManageLinksResponse {
+    cancel_link?: string,
+    reschedule_link?: string,
 }
 
 interface PriceInfo {

--- a/tests/booking.tests.ts
+++ b/tests/booking.tests.ts
@@ -10,6 +10,7 @@ describe('Booking tests', () => {
   const site_name = 'test_site';
   const appointment_type_id = 'test_id'
   const staff_member_id = 'test_id'
+  const appointment_uid = 'test_uid'
 
   const offset = 0;
   const limit = 1;
@@ -26,7 +27,7 @@ describe('Booking tests', () => {
             email: "user@example.com",
             language: "en",
             name: "Default",
-            timeZone: "Asia/Jerusalem"
+            time_zone: "Asia/Jerusalem"
         }
     ],
     booking_fields_responses: {
@@ -45,7 +46,7 @@ describe('Booking tests', () => {
             email: "staffmember1@example.com",
             id: 1582498,
             name: "Staff Member 1",
-            timeZone: "Asia/Jerusalem",
+            time_zone: "Asia/Jerusalem",
             username: "staffmember1-example-com"
         }
     ],
@@ -70,6 +71,15 @@ describe('Booking tests', () => {
       results: [booking_appointment],
       site_name: 'test_site',
       total_responses: 0
+  }
+
+  const manage_appointment_links_response = {
+    cancel_link: 'https://example.com/cancel',
+    reschedule_link: 'https://example.com/reschedule'
+  }
+
+  const send_management_email_response = {
+    sent_to: 'user@example.com'
   }
 
   const booking_appointment_types = {
@@ -146,6 +156,114 @@ describe('Booking tests', () => {
           offset,
           limit
       }).then(res => expect(res).to.eql(list_booking_appointments_response))
+    })
+
+    it('can book an appointment', async () => {
+      scope.post(`${api_path}${site_name}/booking/appointments`, (body) => {
+        expect(body).to.eql({
+          appointment_type_id,
+          attendee: {
+            email: 'user@example.com',
+            language: 'en',
+            name: 'Default',
+            phone_number: '+15555555555',
+            time_zone: 'Asia/Jerusalem'
+          },
+          booking_fields_responses: {
+            email: 'user@example.com',
+            guests: [],
+            name: 'Default'
+          },
+          duration: 30,
+          metadata: {
+            source: 'qa-test'
+          },
+          start: '2025-06-16T17:30:00.000Z'
+        })
+        return body
+      }).reply(200, booking_appointment)
+
+      return await duda.booking.appointments.book({
+        site_name,
+        appointment_type_id,
+        attendee: {
+          email: 'user@example.com',
+          language: 'en',
+          name: 'Default',
+          phone_number: '+15555555555',
+          time_zone: 'Asia/Jerusalem'
+        },
+        booking_fields_responses: {
+          email: 'user@example.com',
+          guests: [],
+          name: 'Default'
+        },
+        duration: 30,
+        metadata: {
+          source: 'qa-test'
+        },
+        start: '2025-06-16T17:30:00.000Z'
+      }).then(res => expect(res).to.eql(booking_appointment))
+    })
+
+    it('can cancel a booking appointment', async () => {
+      scope.post(`${api_path}${site_name}/booking/appointments/${appointment_uid}/cancel`, (body) => {
+        expect(body).to.eql({
+          cancellation_reason: 'Schedule conflict'
+        })
+        return body
+      }).reply(200, booking_appointment)
+
+      return await duda.booking.appointments.cancel({
+        site_name,
+        appointment_uid,
+        cancellation_reason: 'Schedule conflict'
+      }).then(res => expect(res).to.eql(booking_appointment))
+    })
+
+    it('can confirm a booking appointment', async () => {
+      scope.post(`${api_path}${site_name}/booking/appointments/${appointment_uid}/confirm`).reply(200, booking_appointment)
+
+      return await duda.booking.appointments.confirm({
+        site_name,
+        appointment_uid
+      }).then(res => expect(res).to.eql(booking_appointment))
+    })
+
+    it('can get booking appointment manage links', async () => {
+      scope.get(`${api_path}${site_name}/booking/appointments/${appointment_uid}/manage-links?lang=en`).reply(200, manage_appointment_links_response)
+
+      return await duda.booking.appointments.getManageLinks({
+        site_name,
+        appointment_uid,
+        lang: 'en'
+      }).then(res => expect(res).to.eql(manage_appointment_links_response))
+    })
+
+    it('can send a booking appointment management email', async () => {
+      scope.post(`${api_path}${site_name}/booking/appointments/${appointment_uid}/send-management-email`).reply(200, send_management_email_response)
+
+      return await duda.booking.appointments.sendManagementEmail({
+        site_name,
+        appointment_uid
+      }).then(res => expect(res).to.eql(send_management_email_response))
+    })
+
+    it('can reschedule a booking appointment', async () => {
+      scope.post(`${api_path}${site_name}/booking/appointments/${appointment_uid}/reschedule`, (body) => {
+        expect(body).to.eql({
+          rescheduling_reason: 'Availability changed',
+          start: '2025-06-16T17:30:00.000Z'
+        })
+        return body
+      }).reply(200, booking_appointment)
+
+      return await duda.booking.appointments.reschedule({
+        site_name,
+        appointment_uid,
+        rescheduling_reason: 'Availability changed',
+        start: '2025-06-16T17:30:00.000Z'
+      }).then(res => expect(res).to.eql(booking_appointment))
     })
   })
 


### PR DESCRIPTION
## Summary

Adds full appointment lifecycle management to `duda.booking.appointments`, plus fixes to the existing booking types so they match the actual API wire format.

## New endpoints

| Method | Route | SDK call |
|---|---|---|
| POST | `/booking/appointments` | `appointments.book()` |
| POST | `/booking/appointments/{uid}/cancel` | `appointments.cancel()` |
| POST | `/booking/appointments/{uid}/confirm` | `appointments.confirm()` |
| GET | `/booking/appointments/{uid}/manage-links` | `appointments.getManageLinks()` |
| POST | `/booking/appointments/{uid}/send-management-email` | `appointments.sendManagementEmail()` |
| POST | `/booking/appointments/{uid}/reschedule` | `appointments.reschedule()` |

## Type fixes

Corrections to `BookingAppointment` and friends, verified against the backend DTOs and the published OpenAPI reference:

- `attendees` and `hosts` are now arrays (were single objects)
- host `id` is `number` (was `string`)
- attendee `time_zone` is required in the book payload; `phone_number` is optional (was reversed)
- added missing top-level `metadata` and attendee `booking_fields_responses` fields

## Tests & docs

- 7 new tests in `tests/booking.tests.ts` (nock, request-body assertions)
- README entries for every new route, with verified developer-docs reference links

## Stack

1. **Booking Appointment Management Endpoints** ⬅️ this PR
2. Booking Availability Endpoint (`feature/booking-availability`)
3. Booking Widget Embed Endpoint (`feat/booking-widget-embed`)
4. App Store Booking Endpoints (`feat/appstore-bookings`)
