### PR TITLE
Booking Availability Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2116,6 +2116,20 @@ duda.booking.appointments.sendManagementEmail({ site_name: site_name, appointmen
 duda.booking.appointments.reschedule({ site_name: site_name, appointment_uid: appointment_uid, start: start });
 ```
 
+# Booking Availability
+
+## Get Booking Availability
+
+[Get Booking Availability Reference](https://developer.duda.co/reference/booking-availability-get-available-slots)
+
+### Request
+
+`GET https://api.duda.co/api/sites/multiscreen/{site_name}/booking/availability`
+
+```typescript
+duda.booking.getAvailability({ site_name: site_name });
+```
+
 # Booking Appointment Types
 
 ## List Booking Appointment Types

--- a/src/lib/booking/Booking.ts
+++ b/src/lib/booking/Booking.ts
@@ -1,16 +1,46 @@
+import * as Types from './types';
 import Resource from '../base';
 import Appointments from './Appointments';
 import AppointmentTypes from './Appointment_Types';
 import StaffMembers from './Staff_Members';
+import { APIEndpoint } from '../APIEndpoint';
 
 class Booking extends Resource {
-
   appointments = new Appointments(this.config);
 
   appointment_types = new AppointmentTypes(this.config);
 
   staff_members = new StaffMembers(this.config);
 
+  getAvailability = APIEndpoint<Types.GetBookingAvailabilityPayload, Types.GetBookingAvailabilityResponse>({
+    method: 'get',
+    path: '/api/sites/multiscreen/{site_name}/booking/availability',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    queryParams: {
+      appointment_type_id: {
+        type: 'string',
+        required: false,
+      },
+      start: {
+        type: 'string',
+        required: false,
+      },
+      end: {
+        type: 'string',
+        required: false,
+      },
+      time_zone: {
+        type: 'string',
+        required: false,
+      },
+      duration: {
+        type: 'number',
+        required: false,
+      },
+    },
+  })
 }
 
 export default Booking;

--- a/src/lib/booking/types.ts
+++ b/src/lib/booking/types.ts
@@ -363,3 +363,23 @@ export interface UpdateBookingStaffMembersAvailabilityPayload extends BookingSta
 }
 
 export interface UpdateBookingStaffMembersAvailabilityResponse extends BookingStaffMemberAvailability {}
+
+export interface GetBookingAvailabilityPayload {
+    site_name: string,
+    appointment_type_id?: string,
+    start?: string,
+    end?: string,
+    time_zone?: string
+    duration?: number,
+}
+
+export interface BookingAvailabilitySlot {
+    start?: string,
+    end?: string,
+ }
+export interface GetBookingAvailabilityResponse {
+    slots?: {
+        [date: string]: Array<BookingAvailabilitySlot>
+    },
+    time_zone?: string
+}

--- a/tests/booking.tests.ts
+++ b/tests/booking.tests.ts
@@ -82,6 +82,18 @@ describe('Booking tests', () => {
     sent_to: 'user@example.com'
   }
 
+  const booking_availability_response = {
+    slots: {
+      '2025-06-16': [
+        {
+          start: '2025-06-16T17:30:00.000Z',
+          end: '2025-06-16T18:00:00.000Z'
+        }
+      ]
+    },
+    time_zone: 'UTC'
+  }
+
   const booking_appointment_types = {
     created_at: 'string',
     description: 'string',
@@ -264,6 +276,20 @@ describe('Booking tests', () => {
         rescheduling_reason: 'Availability changed',
         start: '2025-06-16T17:30:00.000Z'
       }).then(res => expect(res).to.eql(booking_appointment))
+    })
+  })
+
+  describe('booking availability', () => {
+    it('can get booking availability', async () => {
+      scope.get(`${api_path}${site_name}/booking/availability?appointment_type_id=${appointment_type_id}&start=2025-06-16&end=2025-06-17&time_zone=UTC&duration=30`).reply(200, booking_availability_response)
+      return await duda.booking.getAvailability({
+        site_name,
+        appointment_type_id,
+        start: '2025-06-16',
+        end: '2025-06-17',
+        time_zone: 'UTC',
+        duration: 30
+      }).then(res => expect(res).to.eql(booking_availability_response))
     })
   })
 


### PR DESCRIPTION
## Summary

Adds the booking availability endpoint: `duda.booking.getAvailability()` returns the bookable slot map for a site, bucketed by date in the requested timezone.

## New endpoint

| Method | Route | SDK call |
|---|---|---|
| GET | `/booking/availability` | `booking.getAvailability()` |

Supports the `appointment_type_id`, `start`, `end`, `time_zone`, and `duration` query params. The response `slots` field is typed as a date-keyed map (`{ "YYYY-MM-DD": [{ start, end }] }`), matching the published OpenAPI reference.

## Tests & docs

- New `booking availability` test block in `tests/booking.tests.ts`
- README `# Booking Availability` section with reference link

## Stack

1. Booking Appointment Management Endpoints (`feature/booking-appointments`)
2. **Booking Availability Endpoint** ⬅️ this PR
3. Booking Widget Embed Endpoint (`feat/booking-widget-embed`)
4. App Store Booking Endpoints (`feat/appstore-bookings`)
