### PR TITLE
Booking Widget Embed Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2130,6 +2130,20 @@ duda.booking.appointments.reschedule({ site_name: site_name, appointment_uid: ap
 duda.booking.getAvailability({ site_name: site_name });
 ```
 
+# Booking Widget Embed
+
+## Create Booking Widget Embed
+
+[Create Booking Widget Embed Reference](https://developer.duda.co/reference/booking-widget-embed-get-booking-widget-embed)
+
+### Request
+
+`POST https://api.duda.co/api/sites/multiscreen/{site_name}/booking/widget-embed`
+
+```typescript
+duda.booking.createWidgetEmbed({ site_name: site_name, appointment_type_ids: appointment_type_ids });
+```
+
 # Booking Appointment Types
 
 ## List Booking Appointment Types

--- a/src/lib/booking/Booking.ts
+++ b/src/lib/booking/Booking.ts
@@ -40,7 +40,15 @@ class Booking extends Resource {
         required: false,
       },
     },
-  })
+  });
+
+  createWidgetEmbed = APIEndpoint<Types.CreateBookingWidgetEmbedPayload, Types.CreateBookingWidgetEmbedResponse>({
+    method: 'post',
+    path: '/api/sites/multiscreen/{site_name}/booking/widget-embed',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
 }
 
 export default Booking;

--- a/src/lib/booking/types.ts
+++ b/src/lib/booking/types.ts
@@ -383,3 +383,30 @@ export interface GetBookingAvailabilityResponse {
     },
     time_zone?: string
 }
+
+type DesignStyle = "site-theme" | "basic" 
+
+export interface WidgetEmbedStageConfig {
+    is_title_visible?: boolean,
+    title?: string,
+}
+
+export interface AppointmentStageConfig extends WidgetEmbedStageConfig {}
+
+export interface StaffMemberStageConfig extends WidgetEmbedStageConfig {
+    is_stage_shown?: boolean,
+}
+
+export interface CreateBookingWidgetEmbedPayload {
+    site_name: string,
+    appointment_type_ids: Array<string>,
+    show_free_price?: boolean,
+    design_style?: DesignStyle,
+    lang?: AppointmentAttendeesLanguage,
+    choose_appointment_stage_config?: AppointmentStageConfig,
+    choose_staff_member_stage_config?: StaffMemberStageConfig,
+}
+
+export interface CreateBookingWidgetEmbedResponse {
+    iframe_html?: string,
+}

--- a/tests/booking.tests.ts
+++ b/tests/booking.tests.ts
@@ -82,6 +82,10 @@ describe('Booking tests', () => {
     sent_to: 'user@example.com'
   }
 
+  const booking_widget_embed_response = {
+    iframe_html: '<iframe src="https://example.com/booking-widget"></iframe>'
+  }
+
   const booking_availability_response = {
     slots: {
       '2025-06-16': [
@@ -290,6 +294,46 @@ describe('Booking tests', () => {
         time_zone: 'UTC',
         duration: 30
       }).then(res => expect(res).to.eql(booking_availability_response))
+    })
+  })
+
+  describe('booking widget embed', () => {
+    it('can create a booking widget embed', async () => {
+      scope.post(`${api_path}${site_name}/booking/widget-embed`, (body) => {
+        expect(body).to.eql({
+          appointment_type_ids: [appointment_type_id],
+          show_free_price: true,
+          design_style: 'site-theme',
+          lang: 'en',
+          choose_appointment_stage_config: {
+            is_title_visible: true,
+            title: 'string'
+          },
+          choose_staff_member_stage_config: {
+            is_stage_shown: true,
+            is_title_visible: true,
+            title: 'string'
+          }
+        })
+        return body
+      }).reply(200, booking_widget_embed_response)
+
+      return await duda.booking.createWidgetEmbed({
+        site_name,
+        appointment_type_ids: [appointment_type_id],
+        show_free_price: true,
+        design_style: 'site-theme',
+        lang: 'en',
+        choose_appointment_stage_config: {
+          is_title_visible: true,
+          title: 'string'
+        },
+        choose_staff_member_stage_config: {
+          is_stage_shown: true,
+          is_title_visible: true,
+          title: 'string'
+        }
+      }).then(res => expect(res).to.eql(booking_widget_embed_response))
     })
   })
 


### PR DESCRIPTION
## Summary

Adds the booking widget embed endpoint: `duda.booking.createWidgetEmbed()` returns ready-to-use iframe HTML pointing at the published site's booking widget.

## New endpoint

| Method | Route | SDK call |
|---|---|---|
| POST | `/booking/widget-embed` | `booking.createWidgetEmbed()` |

The payload takes the required `appointment_type_ids` array plus optional `show_free_price`, `design_style` (`site-theme` / `basic`), `lang`, and the `choose_appointment_stage_config` / `choose_staff_member_stage_config` objects. Typings verified against the published OpenAPI reference.

## Tests & docs

- New `booking widget embed` test block in `tests/booking.tests.ts` with full request-body assertion
- README `# Booking Widget Embed` section with reference link

## Stack

1. Booking Appointment Management Endpoints (`feature/booking-appointments`)
2. Booking Availability Endpoint (`feature/booking-availability`)
3. **Booking Widget Embed Endpoint** ⬅️ this PR
4. App Store Booking Endpoints (`feat/appstore-bookings`)
