### PR TITLE
App Store Booking Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -4367,6 +4367,268 @@ duda.appstore.ecomm.carts.list({ site_name: site_name });
 duda.appstore.ecomm.carts.get({ site_name: site_name, cart_id: cart_id });
 ```
 
+# Appstore Booking Appointments
+
+## List Booking Appointments
+
+[List Booking Appointments Reference](https://developer.duda.co/reference/list-booking-appointments)
+
+### Request
+
+`GET https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/appointments`
+
+```typescript
+duda.appstore.booking.appointments.list({ site_name: site_name });
+```
+
+## Book Appointment
+
+[Book Appointment Reference](https://developer.duda.co/reference/booking-appointments-create-booking-appointment)
+
+### Request
+
+`POST https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/appointments`
+
+```typescript
+duda.appstore.booking.appointments.book({ site_name: site_name, appointment_type_id: appointment_type_id, attendee: attendee, start: start });
+```
+
+## Cancel Booking Appointment
+
+[Cancel Booking Appointment Reference](https://developer.duda.co/reference/booking-appointments-cancel-booking-appointment)
+
+### Request
+
+`POST https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/appointments/{appointment_uid}/cancel`
+
+```typescript
+duda.appstore.booking.appointments.cancel({ site_name: site_name, appointment_uid: appointment_uid });
+```
+
+## Confirm Booking Appointment
+
+[Confirm Booking Appointment Reference](https://developer.duda.co/reference/booking-appointments-confirm-booking-appointment)
+
+### Request
+
+`POST https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/appointments/{appointment_uid}/confirm`
+
+```typescript
+duda.appstore.booking.appointments.confirm({ site_name: site_name, appointment_uid: appointment_uid });
+```
+
+## Get Booking Appointment Manage Links
+
+[Get Booking Appointment Manage Links Reference](https://developer.duda.co/reference/booking-appointments-get-manage-links)
+
+### Request
+
+`GET https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/appointments/{appointment_uid}/manage-links`
+
+```typescript
+duda.appstore.booking.appointments.getManageLinks({ site_name: site_name, appointment_uid: appointment_uid });
+```
+
+## Send Booking Appointment Management Email
+
+[Send Booking Appointment Management Email Reference](https://developer.duda.co/reference/booking-appointments-send-management-email)
+
+### Request
+
+`POST https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/appointments/{appointment_uid}/send-management-email`
+
+```typescript
+duda.appstore.booking.appointments.sendManagementEmail({ site_name: site_name, appointment_uid: appointment_uid });
+```
+
+## Reschedule Booking Appointment
+
+[Reschedule Booking Appointment Reference](https://developer.duda.co/reference/booking-appointments-reschedule-booking-appointment)
+
+### Request
+
+`POST https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/appointments/{appointment_uid}/reschedule`
+
+```typescript
+duda.appstore.booking.appointments.reschedule({ site_name: site_name, appointment_uid: appointment_uid, start: start });
+```
+
+# Appstore Booking Availability
+
+## Get Booking Availability
+
+[Get Booking Availability Reference](https://developer.duda.co/reference/booking-availability-get-available-slots)
+
+### Request
+
+`GET https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/availability`
+
+```typescript
+duda.appstore.booking.getAvailability({ site_name: site_name });
+```
+
+# Appstore Booking Widget Embed
+
+## Create Booking Widget Embed
+
+[Create Booking Widget Embed Reference](https://developer.duda.co/reference/booking-widget-embed-get-booking-widget-embed)
+
+### Request
+
+`POST https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/widget-embed`
+
+```typescript
+duda.appstore.booking.createWidgetEmbed({ site_name: site_name, appointment_type_ids: appointment_type_ids });
+```
+
+# Appstore Booking Appointment Types
+
+## List Booking Appointment Types
+
+[List Booking Appointment Types Reference](https://developer.duda.co/reference/list-booking-appointment-types)
+
+### Request
+
+`GET https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/appointment-types`
+
+```typescript
+duda.appstore.booking.appointment_types.list({ site_name: site_name });
+```
+
+## Get Booking Appointment Type
+
+[Get Booking Appointment Type Reference](https://developer.duda.co/reference/get-booking-appointment-type)
+
+### Request
+
+`GET https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/appointment-types/{id}`
+
+```typescript
+duda.appstore.booking.appointment_types.get({ site_name: site_name, id: id });
+```
+
+## Create Booking Appointment Type
+
+[Create Booking Appointment Type Reference](https://developer.duda.co/reference/create-booking-appointment-type)
+
+### Request
+
+`POST https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/appointment-types`
+
+```typescript
+duda.appstore.booking.appointment_types.create({ site_name: site_name });
+```
+
+## Update Booking Appointment Type
+
+[Update Booking Appointment Type Reference](https://developer.duda.co/reference/update-booking-appointment-type)
+
+### Request
+
+`PUT https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/appointment-types/{id}`
+
+```typescript
+duda.appstore.booking.appointment_types.update({ site_name: site_name, id: id });
+```
+
+## Delete Booking Appointment Type
+
+[Delete Booking Appointment Type Reference](https://developer.duda.co/reference/delete-booking-appointment-type)
+
+### Request
+
+`DELETE https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/appointment-types/{id}`
+
+```typescript
+duda.appstore.booking.appointment_types.delete({ site_name: site_name, id: id });
+```
+
+# Appstore Booking Staff Members
+
+## List Booking Staff Members
+
+[List Booking Staff Members Reference](https://developer.duda.co/reference/list-booking-staff-members)
+
+### Request
+
+`GET https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/staff-members`
+
+```typescript
+duda.appstore.booking.staff_members.list({ site_name: site_name });
+```
+
+## Get Booking Staff Member
+
+[Get Booking Staff Member Reference](https://developer.duda.co/reference/get-booking-staff-member)
+
+### Request
+
+`GET https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/staff-members/{id}`
+
+```typescript
+duda.appstore.booking.staff_members.get({ site_name: site_name, id: id });
+```
+
+## Create Booking Staff Member
+
+[Create Booking Staff Member Reference](https://developer.duda.co/reference/create-booking-staff-member)
+
+### Request
+
+`POST https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/staff-members`
+
+```typescript
+duda.appstore.booking.staff_members.create({ site_name: site_name });
+```
+
+## Update Booking Staff Member
+
+[Update Booking Staff Member Reference](https://developer.duda.co/reference/update-booking-staff-member)
+
+### Request
+
+`PUT https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/staff-members/{id}`
+
+```typescript
+duda.appstore.booking.staff_members.update({ site_name: site_name, id: id });
+```
+
+## Delete Booking Staff Member
+
+[Delete Booking Staff Member Reference](https://developer.duda.co/reference/delete-booking-staff-member)
+
+### Request
+
+`DELETE https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/staff-members/{id}`
+
+```typescript
+duda.appstore.booking.staff_members.delete({ site_name: site_name, id: id });
+```
+
+## Get Booking Staff Member Availability
+
+[Get Booking Staff Member Availability Reference](https://developer.duda.co/reference/get-booking-staff-member-availability)
+
+### Request
+
+`GET https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/staff-members/{id}/availability`
+
+```typescript
+duda.appstore.booking.staff_members.availability.get({ site_name: site_name, id: id });
+```
+
+## Update Booking Staff Member Availability
+
+[Update Booking Staff Member Availability Reference](https://developer.duda.co/reference/update-booking-staff-member-availability)
+
+### Request
+
+`PUT https://api.duda.co/api/integrationhub/application/site/{site_name}/booking/staff-members/{id}/availability`
+
+```typescript
+duda.appstore.booking.staff_members.availability.update({ site_name: site_name, id: id });
+```
+
 # Appstore Site Wide HTML
 
 ## List All Site Wide HTML

--- a/src/lib/apps/Apps.ts
+++ b/src/lib/apps/Apps.ts
@@ -13,6 +13,7 @@ import AppsManifest from './manifest/Manifest';
 import AppsAccounts from './accounts/Accounts';
 import AppsEcomm from './ecomm/Ecomm';
 import AppsCollections from './collections/Collections';
+import AppsBooking from './booking/Booking';
 import { RequestOptions } from '../http';
 
 const DEFAULT_EXPIRY_TOLERANCE = 10000;
@@ -53,6 +54,8 @@ class Apps extends Resource {
   ecomm = new AppsEcomm(this);
 
   collections = new AppsCollections(this);
+
+  booking = new AppsBooking(this);
 
   utils = Utils;
 

--- a/src/lib/apps/booking/Appointment_Types.ts
+++ b/src/lib/apps/booking/Appointment_Types.ts
@@ -1,0 +1,74 @@
+import * as Types from './types';
+import { SubResource } from '../../base';
+import { APIEndpoint } from '../../APIEndpoint';
+import { TokenRequest } from '../types';
+
+class AppsAppointmentTypes extends SubResource {
+  list = APIEndpoint<TokenRequest<Types.ListBookingAppointmentTypesPayload>, Types.ListBookingAppointmentTypesResponse>({
+    method: 'get',
+    path: '/site/{site_name}/booking/appointment-types',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  get = APIEndpoint<TokenRequest<Types.GetBookingAppointmentTypesPayload>, Types.GetBookingAppointmentTypesResponse>({
+    method: 'get',
+    path: '/site/{site_name}/booking/appointment-types/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  create = APIEndpoint<TokenRequest<Types.CreateBookingAppointmentTypesPayload>, Types.CreateBookingAppointmentTypesResponse>({
+    method: 'post',
+    path: '/site/{site_name}/booking/appointment-types',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  update = APIEndpoint<TokenRequest<Types.UpdateBookingAppointmentTypesPayload>, Types.UpdateBookingAppointmentTypesResponse>({
+    method: 'put',
+    path: '/site/{site_name}/booking/appointment-types/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  delete = APIEndpoint<TokenRequest<Types.DeleteBookingAppointmentTypesPayload>, Types.DeleteBookingAppointmentTypesResponse>({
+    method: 'delete',
+    path: '/site/{site_name}/booking/appointment-types/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+}
+
+export default AppsAppointmentTypes;
+export { AppsAppointmentTypes };

--- a/src/lib/apps/booking/Appointments.ts
+++ b/src/lib/apps/booking/Appointments.ts
@@ -1,0 +1,152 @@
+import * as Types from './types';
+import { SubResource } from '../../base';
+import { APIEndpoint } from '../../APIEndpoint';
+import { TokenRequest } from '../types';
+
+class AppsAppointments extends SubResource {
+  list = APIEndpoint<TokenRequest<Types.ListBookingAppointmentsPayload>, Types.ListBookingAppointmentsResponse>({
+    method: 'get',
+    path: '/site/{site_name}/booking/appointments',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+    queryParams: {
+      limit: {
+        type: 'number',
+        required: false,
+      },
+      offset: {
+        type: 'number',
+        required: false,
+      },
+      status: {
+        type: 'string',
+        required: false,
+      },
+      mode: {
+        type: 'string',
+        required: false,
+      },
+      attendee_email: {
+        type: 'string',
+        required: false,
+      },
+      appointment_uid: {
+        type: 'string',
+        required: false,
+      },
+      appointment_types: {
+        type: 'string',
+        required: false,
+      },
+      after_start: {
+        type: 'string',
+        required: false,
+      },
+      before_end: {
+        type: 'string',
+        required: false,
+      },
+      after_created_at: {
+        type: 'string',
+        required: false,
+      },
+      before_created_at: {
+        type: 'string',
+        required: false,
+      },
+    },
+  });
+
+  book = APIEndpoint<TokenRequest<Types.BookAppointmentPayload>, Types.BookAppointmentResponse>({
+    method: 'post',
+    path: '/site/{site_name}/booking/appointments',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  cancel = APIEndpoint<TokenRequest<Types.CancelBookingAppointmentPayload>, Types.CancelBookingAppointmentResponse>({
+    method: 'post',
+    path: '/site/{site_name}/booking/appointments/{appointment_uid}/cancel',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  confirm = APIEndpoint<TokenRequest<Types.ConfirmBookingAppointmentPayload>, Types.ConfirmBookingAppointmentResponse>({
+    method: 'post',
+    path: '/site/{site_name}/booking/appointments/{appointment_uid}/confirm',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  getManageLinks = APIEndpoint<TokenRequest<Types.GetAppointmentManageLinksPayload>, Types.GetAppointmentManageLinksResponse>({
+    method: 'get',
+    path: '/site/{site_name}/booking/appointments/{appointment_uid}/manage-links',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+    queryParams: {
+      lang: {
+        type: 'string',
+        required: false,
+      },
+    },
+  });
+
+  sendManagementEmail = APIEndpoint<TokenRequest<Types.SendAppointmentManagementEmailPayload>, Types.SendAppointmentManagementEmailResponse>({
+    method: 'post',
+    path: '/site/{site_name}/booking/appointments/{appointment_uid}/send-management-email',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  reschedule = APIEndpoint<TokenRequest<Types.RescheduleBookingAppointmentPayload>, Types.RescheduleBookingAppointmentResponse>({
+    method: 'post',
+    path: '/site/{site_name}/booking/appointments/{appointment_uid}/reschedule',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+}
+
+export default AppsAppointments;
+export { AppsAppointments };

--- a/src/lib/apps/booking/Availability.ts
+++ b/src/lib/apps/booking/Availability.ts
@@ -1,0 +1,35 @@
+import * as Types from './types';
+import { SubResource } from '../../base';
+import { APIEndpoint } from '../../APIEndpoint';
+import { TokenRequest } from '../types';
+
+class AppsAvailability extends SubResource {
+  get = APIEndpoint<TokenRequest<Types.GetBookingStaffMembersAvailabilityPayload>, Types.GetBookingStaffMembersAvailabilityResponse>({
+    method: 'get',
+    path: '/site/{site_name}/booking/staff-members/{id}/availability',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  update = APIEndpoint<TokenRequest<Types.UpdateBookingStaffMembersAvailabilityPayload>, Types.UpdateBookingStaffMembersAvailabilityResponse>({
+    method: 'put',
+    path: '/site/{site_name}/booking/staff-members/{id}/availability',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+}
+
+export default AppsAvailability;
+export { AppsAvailability };

--- a/src/lib/apps/booking/Booking.ts
+++ b/src/lib/apps/booking/Booking.ts
@@ -1,0 +1,66 @@
+import * as Types from './types';
+import { SubResource } from '../../base';
+import { APIEndpoint } from '../../APIEndpoint';
+import AppsAppointments from './Appointments';
+import AppsAppointmentTypes from './Appointment_Types';
+import AppsStaffMembers from './Staff_Members';
+import { TokenRequest } from '../types';
+
+class AppsBooking extends SubResource {
+  appointments = new AppsAppointments(this.base);
+
+  appointment_types = new AppsAppointmentTypes(this.base);
+
+  staff_members = new AppsStaffMembers(this.base);
+
+  getAvailability = APIEndpoint<TokenRequest<Types.GetBookingAvailabilityPayload>, Types.GetBookingAvailabilityResponse>({
+    method: 'get',
+    path: '/site/{site_name}/booking/availability',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+    queryParams: {
+      appointment_type_id: {
+        type: 'string',
+        required: false,
+      },
+      start: {
+        type: 'string',
+        required: false,
+      },
+      end: {
+        type: 'string',
+        required: false,
+      },
+      time_zone: {
+        type: 'string',
+        required: false,
+      },
+      duration: {
+        type: 'number',
+        required: false,
+      },
+    },
+  });
+
+  createWidgetEmbed = APIEndpoint<TokenRequest<Types.CreateBookingWidgetEmbedPayload>, Types.CreateBookingWidgetEmbedResponse>({
+    method: 'post',
+    path: '/site/{site_name}/booking/widget-embed',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+}
+
+export default AppsBooking;
+export { AppsBooking };

--- a/src/lib/apps/booking/Staff_Members.ts
+++ b/src/lib/apps/booking/Staff_Members.ts
@@ -1,0 +1,77 @@
+import * as Types from './types';
+import { SubResource } from '../../base';
+import { APIEndpoint } from '../../APIEndpoint';
+import AppsAvailability from './Availability';
+import { TokenRequest } from '../types';
+
+class AppsStaffMembers extends SubResource {
+  availability = new AppsAvailability(this.base);
+
+  list = APIEndpoint<TokenRequest<Types.ListBookingStaffMembersPayload>, Types.ListBookingStaffMembersResponse>({
+    method: 'get',
+    path: '/site/{site_name}/booking/staff-members',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  get = APIEndpoint<TokenRequest<Types.GetBookingStaffMembersPayload>, Types.GetBookingStaffMembersResponse>({
+    method: 'get',
+    path: '/site/{site_name}/booking/staff-members/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  create = APIEndpoint<TokenRequest<Types.CreateBookingStaffMembersPayload>, Types.CreateBookingStaffMembersResponse>({
+    method: 'post',
+    path: '/site/{site_name}/booking/staff-members',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  update = APIEndpoint<TokenRequest<Types.UpdateBookingStaffMembersPayload>, Types.UpdateBookingStaffMembersResponse>({
+    method: 'put',
+    path: '/site/{site_name}/booking/staff-members/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  delete = APIEndpoint<TokenRequest<Types.DeleteBookingStaffMembersPayload>, Types.DeleteBookingStaffMembersResponse>({
+    method: 'delete',
+    path: '/site/{site_name}/booking/staff-members/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+}
+
+export default AppsStaffMembers;
+export { AppsStaffMembers };

--- a/src/lib/apps/booking/types.ts
+++ b/src/lib/apps/booking/types.ts
@@ -1,0 +1,1 @@
+export * from '../../booking/types';

--- a/tests/app/booking.tests.ts
+++ b/tests/app/booking.tests.ts
@@ -1,0 +1,526 @@
+import nock from "nock"
+import { expect } from "chai"
+import { Duda } from "../../src/index"
+
+describe('App store booking tests', () => {
+  const base_path = '/api/integrationhub/application'
+  const site_name = 'test_site'
+  const user = 'testuser'
+  const pass = 'testpass'
+  const token = '123456'
+
+  const appointment_type_id = 'test_id'
+  const staff_member_id = 'test_id'
+  const appointment_uid = 'test_uid'
+
+  const offset = 0;
+  const limit = 1;
+
+  const booking_appointment = {
+    absent_host: false,
+    appointment_type: {
+        id: "2660601",
+        slug: "sample-event"
+    },
+    attendees: [
+        {
+            absent:false,
+            email: "user@example.com",
+            language: "en",
+            name: "Default",
+            time_zone: "Asia/Jerusalem"
+        }
+    ],
+    booking_fields_responses: {
+        email: "user@example.com",
+        guests: [],
+        name: "Default"
+    },
+    cancellation_reason: "Schedule conflict",
+    cancelled_by_email: "user@example.com",
+    created_at: "2025-06-16T14:31:58.794Z",
+    description: "string",
+    duration: 30,
+    end: "2025-06-16T18:00:00.000Z",
+    hosts: [
+        {
+            email: "staffmember1@example.com",
+            id: 1582498,
+            name: "Staff Member 1",
+            time_zone: "Asia/Jerusalem",
+            username: "staffmember1-example-com"
+        }
+    ],
+    ics_uid: "kko1gv8tFZe8JjpCpct5tG@Cal.com",
+    id: 8589828,
+    location: "https://app.cal.com/video/kko1gv8tFZe8JjpCpct5tG",
+    rating: 5,
+    recurring_booking_uid: "rec_kko1gv8tFZe8JjpCpct5tG",
+    rescheduled_by_email: "user@example.com",
+    rescheduled_from_uid: "abc123defGHIjkl456MNO",
+    rescheduling_reason: "Availability changed",
+    start: "2025-06-16T17:30:00.000Z",
+    status: "accepted",
+    title: "Sample Event between Staff Member 1 and Default",
+    uid: "kko1gv8tFZe8JjpCpct5tG",
+    updated_at: "2025-06-16T14:31:59.219Z"
+  }
+
+  const list_booking_appointments_response = {
+      limit: 0,
+      offset: 0,
+      results: [booking_appointment],
+      site_name: 'test_site',
+      total_responses: 0
+  }
+
+  const manage_appointment_links_response = {
+    cancel_link: 'https://example.com/cancel',
+    reschedule_link: 'https://example.com/reschedule'
+  }
+
+  const send_management_email_response = {
+    sent_to: 'user@example.com'
+  }
+
+  const booking_widget_embed_response = {
+    iframe_html: '<iframe src="https://example.com/booking-widget"></iframe>'
+  }
+
+  const booking_availability_response = {
+    slots: {
+      '2025-06-16': [
+        {
+          start: '2025-06-16T17:30:00.000Z',
+          end: '2025-06-16T18:00:00.000Z'
+        }
+      ]
+    },
+    time_zone: 'UTC'
+  }
+
+  const booking_appointment_types = {
+    created_at: 'string',
+    description: 'string',
+    duration: 30,
+    id: appointment_type_id,
+    name: 'string',
+    price_info: {
+      base_price: 'string',
+      currency: 'string',
+      formatted_base_price: 'string'
+    },
+    pricing_type: 'string',
+    updated_at: 'string'
+  }
+
+  const list_booking_appointment_types_response = {
+    limit: 0,
+    offset: 0,
+    results: [booking_appointment_types],
+    site_name: site_name,
+    total_responses: 1
+  }
+
+  const booking_staff_member = {
+    account_name: 'string',
+    email: 'string',
+    id: staff_member_id,
+    name: 'string'
+  }
+
+  const list_booking_staff_members_response = {
+    limit: 0,
+    offset: 0,
+    results: [booking_staff_member],
+    site_name: site_name,
+    total_responses: 1
+  }
+
+  const availability = {
+    days: ['MONDAY', 'TUESDAY'],
+    start_time: 'string',
+    end_time: 'string'
+  }
+
+  const overrides = {
+    date: 'string',
+    start_time: 'string',
+    end_time: 'string'
+  }
+
+  const booking_staff_member_availability = {
+    availability: [availability],
+    overrides: [overrides],
+    time_zone: 'string'
+  }
+
+  let duda: Duda;
+  let scope: nock.Scope;
+
+  before(() => {
+    duda = new Duda({
+      user,
+      pass,
+      env: Duda.Envs.direct,
+    })
+
+    scope = nock('https://api.duda.co', {
+      reqheaders: {
+        'x-duda-access-token': `Bearer ${token}`
+      }
+    })
+  })
+
+  describe('booking appointments', () => {
+    it('can list all booking appointments', async () => {
+      scope.get(`${base_path}/site/${site_name}/booking/appointments?offset=${offset}&limit=${limit}`).reply(200, list_booking_appointments_response)
+      return await duda.appstore.booking.appointments.list({
+          site_name,
+          offset,
+          limit,
+          token
+      }).then(res => expect(res).to.eql(list_booking_appointments_response))
+    })
+
+    it('can book an appointment', async () => {
+      scope.post(`${base_path}/site/${site_name}/booking/appointments`, (body) => {
+        expect(body).to.eql({
+          appointment_type_id,
+          attendee: {
+            email: 'user@example.com',
+            language: 'en',
+            name: 'Default',
+            phone_number: '+15555555555',
+            time_zone: 'Asia/Jerusalem'
+          },
+          booking_fields_responses: {
+            email: 'user@example.com',
+            guests: [],
+            name: 'Default'
+          },
+          duration: 30,
+          metadata: {
+            source: 'qa-test'
+          },
+          start: '2025-06-16T17:30:00.000Z'
+        })
+        return body
+      }).reply(200, booking_appointment)
+
+      return await duda.appstore.booking.appointments.book({
+        site_name,
+        appointment_type_id,
+        attendee: {
+          email: 'user@example.com',
+          language: 'en',
+          name: 'Default',
+          phone_number: '+15555555555',
+          time_zone: 'Asia/Jerusalem'
+        },
+        booking_fields_responses: {
+          email: 'user@example.com',
+          guests: [],
+          name: 'Default'
+        },
+        duration: 30,
+        metadata: {
+          source: 'qa-test'
+        },
+        start: '2025-06-16T17:30:00.000Z',
+        token
+      }).then(res => expect(res).to.eql(booking_appointment))
+    })
+
+    it('can cancel a booking appointment', async () => {
+      scope.post(`${base_path}/site/${site_name}/booking/appointments/${appointment_uid}/cancel`, (body) => {
+        expect(body).to.eql({
+          cancellation_reason: 'Schedule conflict'
+        })
+        return body
+      }).reply(200, booking_appointment)
+
+      return await duda.appstore.booking.appointments.cancel({
+        site_name,
+        appointment_uid,
+        cancellation_reason: 'Schedule conflict',
+        token
+      }).then(res => expect(res).to.eql(booking_appointment))
+    })
+
+    it('can confirm a booking appointment', async () => {
+      scope.post(`${base_path}/site/${site_name}/booking/appointments/${appointment_uid}/confirm`).reply(200, booking_appointment)
+
+      return await duda.appstore.booking.appointments.confirm({
+        site_name,
+        appointment_uid,
+        token
+      }).then(res => expect(res).to.eql(booking_appointment))
+    })
+
+    it('can get booking appointment manage links', async () => {
+      scope.get(`${base_path}/site/${site_name}/booking/appointments/${appointment_uid}/manage-links?lang=en`).reply(200, manage_appointment_links_response)
+
+      return await duda.appstore.booking.appointments.getManageLinks({
+        site_name,
+        appointment_uid,
+        lang: 'en',
+        token
+      }).then(res => expect(res).to.eql(manage_appointment_links_response))
+    })
+
+    it('can send a booking appointment management email', async () => {
+      scope.post(`${base_path}/site/${site_name}/booking/appointments/${appointment_uid}/send-management-email`).reply(200, send_management_email_response)
+
+      return await duda.appstore.booking.appointments.sendManagementEmail({
+        site_name,
+        appointment_uid,
+        token
+      }).then(res => expect(res).to.eql(send_management_email_response))
+    })
+
+    it('can reschedule a booking appointment', async () => {
+      scope.post(`${base_path}/site/${site_name}/booking/appointments/${appointment_uid}/reschedule`, (body) => {
+        expect(body).to.eql({
+          rescheduling_reason: 'Availability changed',
+          start: '2025-06-16T17:30:00.000Z'
+        })
+        return body
+      }).reply(200, booking_appointment)
+
+      return await duda.appstore.booking.appointments.reschedule({
+        site_name,
+        appointment_uid,
+        rescheduling_reason: 'Availability changed',
+        start: '2025-06-16T17:30:00.000Z',
+        token
+      }).then(res => expect(res).to.eql(booking_appointment))
+    })
+  })
+
+  describe('booking availability', () => {
+    it('can get booking availability', async () => {
+      scope.get(`${base_path}/site/${site_name}/booking/availability?appointment_type_id=${appointment_type_id}&start=2025-06-16&end=2025-06-17&time_zone=UTC&duration=30`).reply(200, booking_availability_response)
+      return await duda.appstore.booking.getAvailability({
+        site_name,
+        appointment_type_id,
+        start: '2025-06-16',
+        end: '2025-06-17',
+        time_zone: 'UTC',
+        duration: 30,
+        token
+      }).then(res => expect(res).to.eql(booking_availability_response))
+    })
+  })
+
+  describe('booking widget embed', () => {
+    it('can create a booking widget embed', async () => {
+      scope.post(`${base_path}/site/${site_name}/booking/widget-embed`, (body) => {
+        expect(body).to.eql({
+          appointment_type_ids: [appointment_type_id],
+          show_free_price: true,
+          design_style: 'site-theme',
+          lang: 'en',
+          choose_appointment_stage_config: {
+            is_title_visible: true,
+            title: 'string'
+          },
+          choose_staff_member_stage_config: {
+            is_stage_shown: true,
+            is_title_visible: true,
+            title: 'string'
+          }
+        })
+        return body
+      }).reply(200, booking_widget_embed_response)
+
+      return await duda.appstore.booking.createWidgetEmbed({
+        site_name,
+        appointment_type_ids: [appointment_type_id],
+        show_free_price: true,
+        design_style: 'site-theme',
+        lang: 'en',
+        choose_appointment_stage_config: {
+          is_title_visible: true,
+          title: 'string'
+        },
+        choose_staff_member_stage_config: {
+          is_stage_shown: true,
+          is_title_visible: true,
+          title: 'string'
+        },
+        token
+      }).then(res => expect(res).to.eql(booking_widget_embed_response))
+    })
+  })
+
+  describe('booking appointments types', () => {
+    it('can list all booking appointment types', async () => {
+      scope.get(`${base_path}/site/${site_name}/booking/appointment-types`).reply(200, list_booking_appointment_types_response)
+      return await duda.appstore.booking.appointment_types.list({
+          site_name,
+          token
+      }).then(res => expect(res).to.eql(list_booking_appointment_types_response))
+    })
+
+    it('can get a booking appointment type', async () => {
+      scope.get(`${base_path}/site/${site_name}/booking/appointment-types/${appointment_type_id}`).reply(200, booking_appointment_types)
+      return await duda.appstore.booking.appointment_types.get({
+        site_name,
+        id: appointment_type_id,
+        token
+      }).then(res => expect(res).to.eql({ ...booking_appointment_types }))
+    })
+
+    it('can create a booking appointment type', async () => {
+      scope.post(`${base_path}/site/${site_name}/booking/appointment-types`, (body) => {
+        expect(body).to.eql({
+          description: 'string',
+          duration: 30,
+          name: 'string',
+          price_info: {
+            base_price: 'string'
+          },
+          pricing_type: 'string'
+        })
+        return body
+      }).reply(200, booking_appointment_types)
+
+      return await duda.appstore.booking.appointment_types.create({
+        site_name,
+        description: 'string',
+        duration: 30,
+        name: 'string',
+        price_info: {
+          base_price: 'string'
+        },
+        pricing_type: 'string',
+        token
+      })
+    })
+
+    it('can update a booking appointment type', async () => {
+      scope.put(`${base_path}/site/${site_name}/booking/appointment-types/${appointment_type_id}`, (body) => {
+        expect(body).to.eql({
+          description: 'string',
+          duration: 30,
+          name: 'string',
+          price_info: {
+            base_price: 'string'
+          },
+          pricing_type: 'string'
+        })
+        return body
+      }).reply(200, booking_appointment_types)
+
+      return await duda.appstore.booking.appointment_types.update({
+        site_name,
+        id: appointment_type_id,
+        description: 'string',
+        duration: 30,
+        name: 'string',
+        price_info: {
+          base_price: 'string'
+        },
+        pricing_type: 'string',
+        token
+      })
+    })
+
+    it('can delete a booking appointment type', async () => {
+      scope.delete(`${base_path}/site/${site_name}/booking/appointment-types/${appointment_type_id}`).reply(204)
+      return await duda.appstore.booking.appointment_types.delete({
+        site_name,
+        id: appointment_type_id,
+        token
+      })
+    })
+  })
+
+  describe('booking staff members', () => {
+    it('can list all booking staff members', async () => {
+      scope.get(`${base_path}/site/${site_name}/booking/staff-members`).reply(200, list_booking_staff_members_response)
+      return await duda.appstore.booking.staff_members.list({
+          site_name,
+          token
+      }).then(res => expect(res).to.eql(list_booking_staff_members_response))
+    })
+
+    it('can get a booking staff member', async () => {
+      scope.get(`${base_path}/site/${site_name}/booking/staff-members/${staff_member_id}`).reply(200, booking_staff_member)
+      return await duda.appstore.booking.staff_members.get({
+        site_name,
+        id: staff_member_id,
+        token
+      }).then(res => expect(res).to.eql({ ...booking_staff_member }))
+    })
+
+    it('can create a booking staff member', async () => {
+      scope.post(`${base_path}/site/${site_name}/booking/staff-members`, (body) => {
+        expect(body).to.eql({
+          account_name: 'string',
+          email: 'string',
+          name: 'string',
+          timezone: 'string'
+        })
+        return body
+      }).reply(200, booking_staff_member)
+
+      return await duda.appstore.booking.staff_members.create({
+        site_name,
+        account_name: 'string',
+        email: 'string',
+        name: 'string',
+        timezone: 'string',
+        token
+      })
+    })
+
+    it('can update a booking staff member', async () => {
+      scope.put(`${base_path}/site/${site_name}/booking/staff-members/${staff_member_id}`, (body) => {
+        expect(body).to.eql({
+          account_name: 'string',
+          email: 'string',
+          name: 'string'
+        })
+        return body
+      }).reply(200, booking_staff_member)
+
+      return await duda.appstore.booking.staff_members.update({
+        site_name,
+        id: staff_member_id,
+        account_name: 'string',
+        email: 'string',
+        name: 'string',
+        token
+      })
+    })
+
+    it('can delete a booking staff member', async () => {
+      scope.delete(`${base_path}/site/${site_name}/booking/staff-members/${staff_member_id}`).reply(204)
+      return await duda.appstore.booking.staff_members.delete({
+        site_name,
+        id: staff_member_id,
+        token
+      })
+    })
+
+    it('can get a booking staff member availability', async () => {
+      scope.get(`${base_path}/site/${site_name}/booking/staff-members/${staff_member_id}/availability`).reply(200, booking_staff_member_availability)
+      return await duda.appstore.booking.staff_members.availability.get({
+        site_name,
+        id: staff_member_id,
+        token
+      }).then(res => expect(res).to.eql({ ...booking_staff_member_availability }))
+    })
+
+    it('can update a booking staff member availability', async () => {
+      scope.put(`${base_path}/site/${site_name}/booking/staff-members/${staff_member_id}/availability`, (body) => {
+        expect(body).to.eql({ ...booking_staff_member_availability })
+        return body
+      }).reply(200, booking_staff_member_availability)
+
+      return await duda.appstore.booking.staff_members.availability.update({ site_name, id: staff_member_id, ...booking_staff_member_availability, token })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Exposes the entire booking module through the App Store API surface as `duda.appstore.booking`, mirroring how ecomm, collections, and sites are made available to app developers.

## Changes

New `src/lib/apps/booking/` resource following the app-store conventions (`SubResource`, `TokenRequest` payloads, required `X-DUDA-ACCESS-TOKEN` header, integration-hub `/site/{site_name}` paths):

- `Booking.ts` — `getAvailability()` and `createWidgetEmbed()` plus the sub-resources
- `Appointments.ts` — `list`, `book`, `cancel`, `confirm`, `getManageLinks`, `sendManagementEmail`, `reschedule`
- `Appointment_Types.ts` — full CRUD
- `Staff_Members.ts` — full CRUD with nested `availability` get/update
- `types.ts` — re-exports the main booking types
- Wired into `Apps.ts` as `booking = new AppsBooking(this)`

## Tests & docs

- `tests/app/booking.tests.ts` — 21 tests covering every endpoint, asserting the access-token header on each request
- Five new `# Appstore Booking ...` README sections with integration-hub URLs

## Stack

1. Booking Appointment Management Endpoints (`feature/booking-appointments`)
2. Booking Availability Endpoint (`feature/booking-availability`)
3. Booking Widget Embed Endpoint (`feat/booking-widget-embed`)
4. **App Store Booking Endpoints** ⬅️ this PR
