### PR TITLE
Blog Posts Content Query Param

### DIFF
--- a/src/lib/blog/Posts.ts
+++ b/src/lib/blog/Posts.ts
@@ -51,6 +51,10 @@ class Posts extends Resource {
         type: 'number',
         required: false,
       },
+      content: {
+        type: 'boolean',
+        required: false,
+      },
     },
   });
 

--- a/src/lib/blog/types.ts
+++ b/src/lib/blog/types.ts
@@ -94,13 +94,18 @@ export interface GetBlogPostResponse extends BlogPost {
 export interface ListBlogPostsPayload {
     site_name: string,
     limit?: number,
-    offset?: number
+    offset?: number,
+    content?: boolean
+}
+
+export interface ListBlogPostResult extends BlogPost {
+    content?: string,
 }
 
 export interface ListBlogPostsResponse {
     limit: number,
     offset: number,
-    results: Array<GetBlogPostPayload>,
+    results: Array<ListBlogPostResult>,
     total_responses: number
 }
 

--- a/tests/blog.tests.ts.ts
+++ b/tests/blog.tests.ts.ts
@@ -81,6 +81,13 @@ describe('Blog tests', () => {
     total_responses: 1
   }
 
+  const list_blog_posts_with_content = {
+    limit: 1,
+    offset: 0,
+    results: [{ ...blog_post, content: "string" }],
+    total_responses: 1
+  }
+
   before(() => {
     duda = new Duda({
       user: 'testuser',
@@ -186,6 +193,16 @@ describe('Blog tests', () => {
       limit: 1,
       offset: 0
     }).then(res => expect(res).to.eql(list_blog_posts))
+  })
+
+  it('can list all blog posts with their content', async () => {
+    scope.get(`${api_path}/${site_name}/blog/posts?limit=1&offset=0&content=true`).reply(200, list_blog_posts_with_content)
+    return await duda.blog.posts.list({
+      site_name: site_name,
+      limit: 1,
+      offset: 0,
+      content: true
+    }).then(res => expect(res).to.eql(list_blog_posts_with_content))
   })
 
   it('can get a blog post', async () => {


### PR DESCRIPTION
## Summary

Adds the new `content` boolean query param to the blog posts list endpoint, letting callers include each post's content in list results.

## Changes

- `duda.blog.posts.list()` now accepts `content?: boolean`
- New `ListBlogPostResult` type: list results carry an optional `content: string` field; `ListBlogPostsResponse.results` retyped accordingly
- Test covering `content=true` with content-bearing results

## Stack

Merge bottom-up into `release/3.4.0`:

1. Blog Posts Content Query Param (`feat/blog-posts-content-param`)
2. App Store Blog Endpoints (`feat/blogs-appstore`)
3. Async Tasks: Generate Site with AI v2 (`feat/async-site-tasks`)
4. Team Permissions Fixes (`chore/permissions-object`)
5. eComm Product Categories Endpoints (`feat/product-categories`)
6. eComm Shipping Zones Endpoints (`feat/shipping-zones-endpoints`)
7. eComm Carts Fixes (`fix/cart-api`)
