### PR TITLE
App Store Blog Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -4629,6 +4629,106 @@ duda.appstore.booking.staff_members.availability.get({ site_name: site_name, id:
 duda.appstore.booking.staff_members.availability.update({ site_name: site_name, id: id });
 ```
 
+# Appstore Blog
+
+## Get Blog
+
+[Get Blog Reference](https://developer.duda.co/reference/get-blog#/)
+
+### Request
+
+`GET https://api.duda.co/api/integrationhub/application/site/{site_name}/blog`
+
+```typescript
+duda.appstore.blog.get({ site_name: site_name });
+```
+
+# Appstore Blog Posts
+
+## List Blog Posts
+
+[List Blog Posts Reference](https://developer.duda.co/reference/blog-list-blog-posts)
+
+### Request
+
+`GET https://api.duda.co/api/integrationhub/application/site/{site_name}/blog/posts`
+
+```typescript
+duda.appstore.blog.posts.list({ site_name: site_name });
+```
+
+## Get Blog Post
+
+[Get Blog Post Reference](https://developer.duda.co/reference/blog-get-blog-post)
+
+### Request
+
+`GET https://api.duda.co/api/integrationhub/application/site/{site_name}/blog/posts/{post_id}`
+
+```typescript
+duda.appstore.blog.posts.get({ site_name: site_name, post_id: post_id });
+```
+
+## Import Blog Post
+
+[Import Blog Post Reference](https://developer.duda.co/reference/import-blog-post)
+
+### Request
+
+`POST https://api.duda.co/api/integrationhub/application/site/{site_name}/blog/posts/import`
+
+```typescript
+duda.appstore.blog.posts.import({ site_name: site_name });
+```
+
+## Publish Blog Post
+
+[Publish Blog Post Reference](https://developer.duda.co/reference/blog-publish-blog-post)
+
+### Request
+
+`POST https://api.duda.co/api/integrationhub/application/site/{site_name}/blog/posts/{post_id}/publish`
+
+```typescript
+duda.appstore.blog.posts.publish({ site_name: site_name, post_id: post_id });
+```
+
+## Unpublish Blog Post
+
+[Unpublish Blog Post Reference](https://developer.duda.co/reference/blog-unpublish-blog-post)
+
+### Request
+
+`POST https://api.duda.co/api/integrationhub/application/site/{site_name}/blog/posts/{post_id}/unpublish`
+
+```typescript
+duda.appstore.blog.posts.unpublish({ site_name: site_name, post_id: post_id });
+```
+
+## Update Blog Post
+
+[Update Blog Post Reference](https://developer.duda.co/reference/blog-update-blog-post)
+
+### Request
+
+`PATCH https://api.duda.co/api/integrationhub/application/site/{site_name}/blog/posts/{post_id}`
+
+```typescript
+duda.appstore.blog.posts.update({ site_name: site_name, post_id: post_id });
+```
+
+## Delete Blog Post
+
+[Delete Blog Post Reference](https://developer.duda.co/reference/blog-delete-blog-post)
+
+### Request
+
+`DELETE https://api.duda.co/api/integrationhub/application/site/{site_name}/blog/posts/{post_id}`
+
+```typescript
+duda.appstore.blog.posts.delete({ site_name: site_name, post_id: post_id });
+```
+
 # Appstore Site Wide HTML
 
 ## List All Site Wide HTML

--- a/src/lib/apps/Apps.ts
+++ b/src/lib/apps/Apps.ts
@@ -14,6 +14,7 @@ import AppsAccounts from './accounts/Accounts';
 import AppsEcomm from './ecomm/Ecomm';
 import AppsCollections from './collections/Collections';
 import AppsBooking from './booking/Booking';
+import AppsBlog from './blog/Blog';
 import { RequestOptions } from '../http';
 
 const DEFAULT_EXPIRY_TOLERANCE = 10000;
@@ -56,6 +57,8 @@ class Apps extends Resource {
   collections = new AppsCollections(this);
 
   booking = new AppsBooking(this);
+
+  blog = new AppsBlog(this);
 
   utils = Utils;
 

--- a/src/lib/apps/blog/Blog.ts
+++ b/src/lib/apps/blog/Blog.ts
@@ -1,0 +1,25 @@
+import * as Types from './types';
+import { SubResource } from '../../base';
+import { APIEndpoint } from '../../APIEndpoint';
+import AppsPosts from './Posts';
+import { TokenRequest } from '../types';
+
+class AppsBlog extends SubResource {
+  posts = new AppsPosts(this.base);
+
+  get = APIEndpoint<TokenRequest<Types.GetBlogPayload>, Types.GetBlogResponse>({
+    method: 'get',
+    path: '/site/{site_name}/blog',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+}
+
+export default AppsBlog;
+export { AppsBlog };

--- a/src/lib/apps/blog/Posts.ts
+++ b/src/lib/apps/blog/Posts.ts
@@ -1,0 +1,114 @@
+import * as Types from './types';
+import { SubResource } from '../../base';
+import { APIEndpoint } from '../../APIEndpoint';
+import { TokenRequest } from '../types';
+
+class AppsPosts extends SubResource {
+  import = APIEndpoint<TokenRequest<Types.ImportBlogPostPayload>, Types.ImportBlogPostResponse>({
+    method: 'post',
+    path: '/site/{site_name}/blog/posts/import',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  publish = APIEndpoint<TokenRequest<Types.PublishBlogPostPayload>, Types.PublishBlogPostResponse>({
+    method: 'post',
+    path: '/site/{site_name}/blog/posts/{post_id}/publish',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  unpublish = APIEndpoint<TokenRequest<Types.UnpublishBlogPostPayload>, Types.UnpublishBlogPostResponse>({
+    method: 'post',
+    path: '/site/{site_name}/blog/posts/{post_id}/unpublish',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  update = APIEndpoint<TokenRequest<Types.UpdateBlogPostPayload>, Types.UpdateBlogPostResponse>({
+    method: 'patch',
+    path: '/site/{site_name}/blog/posts/{post_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  list = APIEndpoint<TokenRequest<Types.ListBlogPostsPayload>, Types.ListBlogPostsResponse>({
+    method: 'get',
+    path: '/site/{site_name}/blog/posts',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+    queryParams: {
+      limit: {
+        type: 'number',
+        required: false,
+      },
+      offset: {
+        type: 'number',
+        required: false,
+      },
+      content: {
+        type: 'boolean',
+        required: false,
+      },
+    },
+  });
+
+  get = APIEndpoint<TokenRequest<Types.GetBlogPostPayload>, Types.GetBlogPostResponse>({
+    method: 'get',
+    path: '/site/{site_name}/blog/posts/{post_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  delete = APIEndpoint<TokenRequest<Types.DeleteBlogPostPayload>, Types.DeleteBlogPostResponse>({
+    method: 'delete',
+    path: '/site/{site_name}/blog/posts/{post_id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+}
+
+export default AppsPosts;
+export { AppsPosts };

--- a/src/lib/apps/blog/types.ts
+++ b/src/lib/apps/blog/types.ts
@@ -1,0 +1,1 @@
+export * from '../../blog/types';

--- a/tests/app/blog.tests.ts
+++ b/tests/app/blog.tests.ts
@@ -1,0 +1,194 @@
+import nock from "nock"
+import { expect } from "chai"
+import { Duda } from "../../src/index"
+
+describe('App store blog tests', () => {
+  const base_path = '/api/integrationhub/application'
+  const site_name = 'test_site'
+  const user = 'testuser'
+  const pass = 'testpass'
+  const token = '123456'
+  const post_id = 'post_id'
+
+  const blog = {
+    name: "string",
+    title: "string",
+    description: "string",
+    image: "string",
+    image_alt_text: "string"
+  }
+
+  const import_blog_post_object = {
+    title: 'title',
+    description: 'description',
+    content: 'content',
+    author: 'author',
+    thumbnail: {
+      url: 'url'
+    },
+    main_image: {
+      url: 'url'
+    }
+  }
+
+  const update_blog_post_payload = {
+    author_name: "string",
+    description: "string",
+    meta_title: "string",
+    no_index: true,
+    path: "string",
+    publish_date: "string",
+    tags: ["string"],
+    title: "string",
+    schedule_publish_date: "string"
+  }
+
+  const blog_post = {
+    author_name: "string",
+    creation_date: "string",
+    description: "string",
+    id: "string",
+    meta_title: "string",
+    no_index: true,
+    path: "string",
+    publish_date: "string",
+    schedule_publish_date: "string",
+    status: "string",
+    tags: ["string"],
+    title: "string",
+    main_image: {
+      url: "string"
+    },
+    thumbnail: {
+      url: "string"
+    }
+  }
+
+  const list_blog_posts = {
+    limit: 1,
+    offset: 0,
+    results: [blog_post],
+    total_responses: 1
+  }
+
+  const list_blog_posts_with_content = {
+    limit: 1,
+    offset: 0,
+    results: [{ ...blog_post, content: "string" }],
+    total_responses: 1
+  }
+
+  let duda: Duda;
+  let scope: nock.Scope;
+
+  before(() => {
+    duda = new Duda({
+      user,
+      pass,
+      env: Duda.Envs.direct
+    })
+
+    scope = nock('https://api.duda.co', {
+      reqheaders: {
+        'x-duda-access-token': `Bearer ${token}`
+      }
+    })
+  })
+
+  it('can get a blog', async () => {
+    scope.get(`${base_path}/site/${site_name}/blog`).reply(200, blog)
+    return await duda.appstore.blog.get({
+      site_name,
+      token
+    }).then(res => expect(res).to.eql(blog))
+  })
+
+  it('can import a blog post', async () => {
+    scope.post(`${base_path}/site/${site_name}/blog/posts/import`, (body) => {
+      expect(body).to.eql({ ...import_blog_post_object })
+      return body
+    }).reply(200, import_blog_post_object)
+
+    return await duda.appstore.blog.posts.import({
+      site_name,
+      title: 'title',
+      description: 'description',
+      content: 'content',
+      author: 'author',
+      thumbnail: {
+        url: 'url'
+      },
+      main_image: {
+        url: 'url'
+      },
+      token
+    })
+  })
+
+  it('can publish a blog post', async () => {
+    scope.post(`${base_path}/site/${site_name}/blog/posts/${post_id}/publish`).reply(204)
+    return await duda.appstore.blog.posts.publish({
+      site_name,
+      post_id,
+      token
+    })
+  })
+
+  it('can unpublish a blog post', async () => {
+    scope.post(`${base_path}/site/${site_name}/blog/posts/${post_id}/unpublish`).reply(204)
+    return await duda.appstore.blog.posts.unpublish({
+      site_name,
+      post_id,
+      token
+    })
+  })
+
+  it('can update a blog post', async () => {
+    scope.patch(`${base_path}/site/${site_name}/blog/posts/${post_id}`).reply(200, blog_post)
+    return await duda.appstore.blog.posts.update({
+      site_name,
+      post_id,
+      ...update_blog_post_payload,
+      token
+    }).then(res => expect(res).to.eql(blog_post))
+  })
+
+  it('can list all blog posts', async () => {
+    scope.get(`${base_path}/site/${site_name}/blog/posts?limit=1&offset=0`).reply(200, list_blog_posts)
+    return await duda.appstore.blog.posts.list({
+      site_name,
+      limit: 1,
+      offset: 0,
+      token
+    }).then(res => expect(res).to.eql(list_blog_posts))
+  })
+
+  it('can list all blog posts with their content', async () => {
+    scope.get(`${base_path}/site/${site_name}/blog/posts?limit=1&offset=0&content=true`).reply(200, list_blog_posts_with_content)
+    return await duda.appstore.blog.posts.list({
+      site_name,
+      limit: 1,
+      offset: 0,
+      content: true,
+      token
+    }).then(res => expect(res).to.eql(list_blog_posts_with_content))
+  })
+
+  it('can get a blog post', async () => {
+    scope.get(`${base_path}/site/${site_name}/blog/posts/${post_id}`).reply(200, blog_post)
+    return await duda.appstore.blog.posts.get({
+      site_name,
+      post_id,
+      token
+    }).then(res => expect(res).to.eql(blog_post))
+  })
+
+  it('can delete a blog post', async () => {
+    scope.delete(`${base_path}/site/${site_name}/blog/posts/${post_id}`).reply(204)
+    return await duda.appstore.blog.posts.delete({
+      site_name,
+      post_id,
+      token
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Exposes the blog module through the App Store API surface as `duda.appstore.blog`, limited to the 8 endpoints the integration hub actually serves.

## Changes

- New `src/lib/apps/blog/` resource (`SubResource`, `TokenRequest`, required `X-DUDA-ACCESS-TOKEN`, integration-hub paths):
  - `blog.get`
  - `blog.posts`: `list` (with `limit`/`offset`/`content`), `get`, `import`, `publish`, `unpublish`, `update`, `delete`
- Wired into `Apps.ts` as `blog = new AppsBlog(this)`
- 9 tests asserting the access-token header on every request
- README `# Appstore Blog` / `# Appstore Blog Posts` sections

## Stack

Merge bottom-up into `release/3.4.0`:

1. Blog Posts Content Query Param (`feat/blog-posts-content-param`)
2. App Store Blog Endpoints (`feat/blogs-appstore`)
3. Async Tasks: Generate Site with AI v2 (`feat/async-site-tasks`)
4. Team Permissions Fixes (`chore/permissions-object`)
5. eComm Product Categories Endpoints (`feat/product-categories`)
6. eComm Shipping Zones Endpoints (`feat/shipping-zones-endpoints`)
7. eComm Carts Fixes (`fix/cart-api`)
