### PR TITLE
Async Tasks: Generate Site with AI v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,18 @@ duda.sites.theme.update({ site_name: site_name });
 duda.async.generate();
 ```
 
+## Generate Site with AI from a Prompt
+
+[Generate Site with AI from a Prompt Reference](https://developer.duda.co/reference/generate-site-with-ai-v2)
+
+### Request
+
+`POST https://api.duda.co/api/async-tasks/v2/generate-site-with-ai`
+
+```typescript
+duda.async.generateFromPrompt({ business_data: business_data, instructions: instructions });
+```
+
 ## Get Task
 
 [Get Task Reference](https://developer.duda.co/reference/get-task#/)

--- a/src/lib/async tasks/Async.ts
+++ b/src/lib/async tasks/Async.ts
@@ -13,6 +13,14 @@ class Async extends Resource {
     },
   });
 
+  generateFromPrompt = APIEndpoint<Types.GenerateSiteFromPromptPayload, Types.GenerateSiteFromPromptResponse>({
+    method: 'post',
+    path: '/api/async-tasks/v2/generate-site-with-ai',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
   get = APIEndpoint<Types.GetAsyncPayload, Types.GetAsyncResponse>({
     method: 'get',
     path: '/api/async-tasks/{task_id}',

--- a/src/lib/async tasks/types.ts
+++ b/src/lib/async tasks/types.ts
@@ -1,5 +1,21 @@
+type BusinessDataToneOfVoice =
+    'CONVERSATIONAL' |
+    'HUMOROUS' |
+    'ENTHUSIASTIC' |
+    'INFORMATIVE' |
+    'PROFESSIONAL' |
+    'WITTY' |
+    'AUTHORITATIVE';
+
+interface AIGeneratedPage {
+    title: string,
+    description?: string
+}
+
 interface AdditionalAIContext {
-    max_pages?: number
+    instructions?: string,
+    max_pages?: number,
+    pages?: Array<AIGeneratedPage>
 }
 
 interface BusinessData {
@@ -9,7 +25,7 @@ interface BusinessData {
     logo_url?: string,
     name: string,
     service_area?: string,
-    tone_of_voice?: string
+    tone_of_voice?: BusinessDataToneOfVoice
 }
 
 interface Labels {
@@ -60,7 +76,9 @@ interface SiteThemeColor  {
 }
 
 interface BreakpointOverrides {
-    font_size?: string
+    text?: {
+        font_size?: string
+    }
 }
 
 interface ThemeBreakpoints {
@@ -96,15 +114,6 @@ interface Theme {
     text?: ThemeTextStyles
 }
 
-type BusinessDataToneOfVoice =
-    'CONVERSATIONAL' |
-    'HUMOROUS' |
-    'ENTHUSIASTIC' |
-    'INFORMATIVE' |
-    'PROFESSIONAL' |
-    'WITTY' |
-    'AUTHORITATIVE';
-
 interface GenerateFromPromptBusinessData {
     category?: string,
     data_controller?: string,
@@ -118,12 +127,13 @@ interface GenerateFromPromptBusinessData {
 
 export interface GenerateAsyncPayload {
     additional_ai_context?: AdditionalAIContext,
-    business_data?: BusinessData,
+    business_data: BusinessData,
     default_domain_prefix?: string,
     do_not_gen_ssl?: boolean,
     labels?: Array<Labels>,
     lang?: string,
     site_data?: SiteData,
+    template_alias?: string,
     theme?: Theme
 }
 

--- a/src/lib/async tasks/types.ts
+++ b/src/lib/async tasks/types.ts
@@ -96,6 +96,26 @@ interface Theme {
     text?: ThemeTextStyles
 }
 
+type BusinessDataToneOfVoice =
+    'CONVERSATIONAL' |
+    'HUMOROUS' |
+    'ENTHUSIASTIC' |
+    'INFORMATIVE' |
+    'PROFESSIONAL' |
+    'WITTY' |
+    'AUTHORITATIVE';
+
+interface GenerateFromPromptBusinessData {
+    category?: string,
+    data_controller?: string,
+    description?: string,
+    logo_alt_text?: string,
+    logo_url?: string,
+    name?: string,
+    service_area?: string,
+    tone_of_voice?: BusinessDataToneOfVoice
+}
+
 export interface GenerateAsyncPayload {
     additional_ai_context?: AdditionalAIContext,
     business_data?: BusinessData,
@@ -135,3 +155,10 @@ export interface GetAsyncResponse {
     created_at: string,
     finished_at?: string
 }
+
+export interface GenerateSiteFromPromptPayload {
+    business_data: GenerateFromPromptBusinessData,
+    instructions: string
+}
+
+export interface GenerateSiteFromPromptResponse extends GetAsyncResponse {}

--- a/tests/async.tests.ts
+++ b/tests/async.tests.ts
@@ -10,7 +10,13 @@ describe('Async Tasks tests', () => {
   const task_id = 'test_task';
 
   const additional_ai_context = {
-    max_pages: 1
+    instructions: 'string',
+    pages: [
+      {
+        title: 'string',
+        description: 'string'
+      }
+    ]
   }
 
   const business_data = {
@@ -20,7 +26,7 @@ describe('Async Tasks tests', () => {
     logo_url: 'string',
     name: 'string',
     service_area: 'string',
-    tone_of_voice: 'string'
+    tone_of_voice: 'PROFESSIONAL' as const
   }
 
   const labels = {
@@ -81,7 +87,9 @@ describe('Async Tasks tests', () => {
         font_style: "string",
         breakpoints: {
           mobile: {
-              font_size: "string"
+              text: {
+                font_size: "string"
+              }
           }
         }
       }
@@ -100,6 +108,7 @@ describe('Async Tasks tests', () => {
     labels: [labels],
     lang: 'en',
     site_data: site_data,
+    template_alias: 'string',
     theme: theme
   }
 

--- a/tests/async.tests.ts
+++ b/tests/async.tests.ts
@@ -110,6 +110,27 @@ describe('Async Tasks tests', () => {
     created_at: 'string'
   }
 
+  const generate_site_from_prompt_payload = {
+    business_data: {
+      category: 'string',
+      data_controller: 'string',
+      description: 'string',
+      logo_alt_text: 'string',
+      logo_url: 'string',
+      name: 'string',
+      service_area: 'string',
+      tone_of_voice: 'PROFESSIONAL' as const
+    },
+    instructions: 'string'
+  }
+
+  const generate_site_from_prompt_response = {
+    id: task_id,
+    type: 'GENERATE_SITE_WITH_AI',
+    status: 'CREATED',
+    created_at: 'string'
+  }
+
   const get_async_task_response = {
     id: task_id,
     type: 'GENERATE_SITE_WITH_AI',
@@ -138,6 +159,16 @@ describe('Async Tasks tests', () => {
     }).reply(200, generate_ai_site_response)
 
     return await duda.async.generate({ ...generate_ai_site_payload })
+  })
+
+  it('can generate a site with AI from a prompt', async () => {
+    scope.post(`/api/async-tasks/v2/generate-site-with-ai`, (body) => {
+      expect(body).to.eql({ ...generate_site_from_prompt_payload })
+      return body
+    }).reply(200, generate_site_from_prompt_response)
+
+    return await duda.async.generateFromPrompt({ ...generate_site_from_prompt_payload })
+      .then(res => expect(res).to.eql({ ...generate_site_from_prompt_response }))
   })
 
   it('can get an async task', async () => {


### PR DESCRIPTION
## Summary

Adds the async-tasks v2 endpoint `duda.async.generateFromPrompt()` (`POST /api/async-tasks/v2/generate-site-with-ai`) and aligns the v1 `generate` typings with the published OpenAPI reference.

## Changes

**New v2 endpoint**
- `GenerateSiteFromPromptPayload`: required `business_data` + `instructions`; `tone_of_voice` typed as the 7-value enum

**v1 typing fixes (verified against the reference doc)**
- `business_data` is now required; `tone_of_voice` uses the shared enum
- `additional_ai_context` gains `instructions` and `pages` (`title` required, `description` optional)
- Added root-level `template_alias`
- Fixed text-style breakpoint nesting: `breakpoints.mobile.text.font_size` (previous shape never matched the API)

- Tests for both endpoints; README entry for the v2 route

## Stack

Merge bottom-up into `release/3.4.0`:

1. Blog Posts Content Query Param (`feat/blog-posts-content-param`)
2. App Store Blog Endpoints (`feat/blogs-appstore`)
3. Async Tasks: Generate Site with AI v2 (`feat/async-site-tasks`)
4. Team Permissions Fixes (`chore/permissions-object`)
5. eComm Product Categories Endpoints (`feat/product-categories`)
6. eComm Shipping Zones Endpoints (`feat/shipping-zones-endpoints`)
7. eComm Carts Fixes (`fix/cart-api`)
