### PR TITLE
Team Permissions Fixes

### DIFF
--- a/src/lib/accounts/types.ts
+++ b/src/lib/accounts/types.ts
@@ -155,7 +155,7 @@ type TeamPermissions =
   'LIMIT_EDITING' |
   'CONTENT_LIBRARY' |
   'E_COMMERCE' |
-	'CO_PILOT' |
+  'COPILOT' |
   'ACTIVITY_LOG' |
   'INSTALL_APP' |
   'PRO_SETTINGS' |
@@ -168,13 +168,16 @@ type TeamPermissions =
   'PUBLISH' |
   'CUSTOM_DOMAIN' |
   'BLOG' |
+  'PUSH_NOTIFICATIONS' |
+  'BOOKING_ADMIN' |
+  'ACCOUNT_ADDONS_AND_CREDITS' |
   string;
 
 export interface TeamGroups {
   group_name?: string,
   color?: string,
   title: string,
-  permissions?: TeamPermissions
+  permissions?: Array<TeamPermissions>
 }
 
 export type ListCustomTeamGroupsPayload = null;


### PR DESCRIPTION
## Summary

Aligns the `TeamPermissions` type with the backend permission enum and fixes the team groups typing.

## Changes

- Renamed misspelled `CO_PILOT` → `COPILOT`
- Added missing permissions: `PUSH_NOTIFICATIONS`, `BOOKING_ADMIN`, `ACCOUNT_ADDONS_AND_CREDITS`
- `TeamGroups.permissions` is now `Array<TeamPermissions>` (single value never matched the documented response, which returns an array per group)

## Stack

Merge bottom-up into `release/3.4.0`:

1. Blog Posts Content Query Param (`feat/blog-posts-content-param`)
2. App Store Blog Endpoints (`feat/blogs-appstore`)
3. Async Tasks: Generate Site with AI v2 (`feat/async-site-tasks`)
4. Team Permissions Fixes (`chore/permissions-object`)
5. eComm Product Categories Endpoints (`feat/product-categories`)
6. eComm Shipping Zones Endpoints (`feat/shipping-zones-endpoints`)
7. eComm Carts Fixes (`fix/cart-api`)
