### PR TITLE
eComm Product Categories Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1639,6 +1639,44 @@ duda.ecomm.categories.bulkCreate({ site_name: site_name });
 duda.ecomm.categories.bulkUpdate({ site_name: site_name });
 ```
 
+# eComm Product Categories
+
+## List Product Categories
+
+[List Product Categories Reference](https://developer.duda.co/reference/ecommerce-list-product-categories)
+
+### Request
+
+`GET https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/product-categories`
+
+```typescript
+duda.ecomm.product_categories.list({ site_name: site_name });
+```
+
+## Create Product Categories
+
+[Create Product Categories Reference](https://developer.duda.co/reference/ecommerce-create-product-categories)
+
+### Request
+
+`POST https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/product-categories`
+
+```typescript
+duda.ecomm.product_categories.create({ site_name: site_name, relations: relations });
+```
+
+## Delete Product Categories
+
+[Delete Product Categories Reference](https://developer.duda.co/reference/ecommerce-delete-product-categories)
+
+### Request
+
+`POST https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/product-categories/delete`
+
+```typescript
+duda.ecomm.product_categories.delete({ site_name: site_name, relations: relations });
+```
+
 # eComm Shipping Providers
 
 ## List Shipping Providers

--- a/src/lib/ecomm/Ecomm.ts
+++ b/src/lib/ecomm/Ecomm.ts
@@ -6,6 +6,7 @@ import Orders from './Orders';
 import Gateways from './Gateways';
 import Payments from './Payments';
 import Categories from './Categories';
+import ProductCategories from './Product_Categories';
 import Shipping from './Shipping';
 import Products from './Products';
 import Options from './Options';
@@ -30,6 +31,8 @@ class Ecomm extends Resource {
   payments = new Payments(this.config);
 
   categories = new Categories(this.config);
+
+  product_categories = new ProductCategories(this.config);
 
   shipping = new Shipping(this.config);
 

--- a/src/lib/ecomm/Product_Categories.ts
+++ b/src/lib/ecomm/Product_Categories.ts
@@ -1,0 +1,46 @@
+import * as Types from './types';
+import Resource from '../base';
+import { APIEndpoint } from '../APIEndpoint';
+
+class ProductCategories extends Resource {
+  list = APIEndpoint<Types.ListProductCategoriesPayload, Types.ListProductCategoriesResponse>({
+    method: 'get',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/product-categories',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    queryParams: {
+      category_ids: {
+        type: 'string',
+        required: false,
+      },
+      limit: {
+        type: 'number',
+        required: false,
+      },
+      cursor: {
+        type: 'string',
+        required: false,
+      },
+    },
+  });
+
+  create = APIEndpoint<Types.CreateProductCategoriesPayload, Types.CreateProductCategoriesResponse>({
+    method: 'post',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/product-categories',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  delete = APIEndpoint<Types.DeleteProductCategoriesPayload, Types.DeleteProductCategoriesResponse>({
+    method: 'post',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/product-categories/delete',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+}
+
+export default ProductCategories;
+export { ProductCategories };

--- a/src/lib/ecomm/types.ts
+++ b/src/lib/ecomm/types.ts
@@ -988,6 +988,41 @@ export interface BulkUpdateCategoryPayload {
 
 export interface BulkUpdateCategoryResponse extends BulkCreateCategoryResponse {}
 
+interface ProductCategoryRelation {
+  category_id: string,
+  product_id: string,
+  order?: number
+}
+
+export interface ListProductCategoriesPayload {
+  site_name: string,
+  category_ids?: string,
+  limit?: number,
+  cursor?: string
+}
+
+export interface ListProductCategoriesResponse {
+  site_name: string,
+  results: Array<ProductCategoryRelation>,
+  cursor?: string,
+  has_more?: boolean,
+  next_page?: string
+}
+
+export interface CreateProductCategoriesPayload {
+  site_name: string,
+  relations: Array<ProductCategoryRelation>
+}
+
+export type CreateProductCategoriesResponse = null;
+
+export interface DeleteProductCategoriesPayload {
+  site_name: string,
+  relations: Array<ProductCategoryRelation>
+}
+
+export type DeleteProductCategoriesResponse = null;
+
 export interface ShippingProvider {
   id: string,
   live_shipping_rates_url: string,

--- a/tests/ecomm.tests.ts
+++ b/tests/ecomm.tests.ts
@@ -1041,6 +1041,30 @@ describe('Ecomm tests', () => {
     ]
   }
 
+  const product_categories_relations_payload = {
+    relations: [
+      {
+        category_id: category_id,
+        product_id: product_id,
+        order: 0
+      }
+    ]
+  }
+
+  const list_product_categories_response = {
+    site_name: site_name,
+    results: [
+      {
+        product_id: product_id,
+        category_id: category_id,
+        order: 0
+      }
+    ],
+    cursor: "string",
+    has_more: false,
+    next_page: "string"
+  }
+
   const bulk_update_category_payload = {
     categories: [
       {
@@ -1663,6 +1687,34 @@ describe('Ecomm tests', () => {
     }).reply(200, bulk_category_response)
 
     return await duda.ecomm.categories.bulkUpdate({ site_name, ...bulk_update_category_payload })
+  })
+
+  it('can list product categories', async () => {
+    scope.get(`/api/sites/multiscreen/${site_name}/ecommerce/product-categories?category_ids=${category_id}&limit=1&cursor=cursor`).reply(200, list_product_categories_response)
+    return await duda.ecomm.product_categories.list({
+      site_name,
+      category_ids: category_id,
+      limit: 1,
+      cursor: 'cursor'
+    }).then(res => expect(res).to.eql(list_product_categories_response))
+  })
+
+  it('can create product categories', async () => {
+    scope.post(`/api/sites/multiscreen/${site_name}/ecommerce/product-categories`, (body) => {
+      expect(body).to.eql({ ...product_categories_relations_payload })
+      return body
+    }).reply(204)
+
+    return await duda.ecomm.product_categories.create({ site_name, ...product_categories_relations_payload })
+  })
+
+  it('can delete product categories', async () => {
+    scope.post(`/api/sites/multiscreen/${site_name}/ecommerce/product-categories/delete`, (body) => {
+      expect(body).to.eql({ ...product_categories_relations_payload })
+      return body
+    }).reply(204)
+
+    return await duda.ecomm.product_categories.delete({ site_name, ...product_categories_relations_payload })
   })
 
   it('can list all shipping providers', async () => {


### PR DESCRIPTION
## Summary

Adds the bulk product↔category relation endpoints as `duda.ecomm.product_categories`.

## Changes

| SDK call | Endpoint |
|---|---|
| `list` | `GET .../ecommerce/product-categories` (`category_ids`, `limit`, `cursor` — cursor-paginated) |
| `create` | `POST .../product-categories` (`relations`, max 1000/request) |
| `delete` | `POST .../product-categories/delete` (`relations`) |

- Shared `ProductCategoryRelation` type (`category_id`, `product_id`, `order?`)
- 3 tests with request-body assertions; README `# eComm Product Categories` section

## Stack

Merge bottom-up into `release/3.4.0`:

1. Blog Posts Content Query Param (`feat/blog-posts-content-param`)
2. App Store Blog Endpoints (`feat/blogs-appstore`)
3. Async Tasks: Generate Site with AI v2 (`feat/async-site-tasks`)
4. Team Permissions Fixes (`chore/permissions-object`)
5. eComm Product Categories Endpoints (`feat/product-categories`)
6. eComm Shipping Zones Endpoints (`feat/shipping-zones-endpoints`)
7. eComm Carts Fixes (`fix/cart-api`)
