### PR TITLE
eComm Shipping Zones Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1742,6 +1742,116 @@ duda.ecomm.shipping.update({ site_name: site_name, id: id });
 duda.ecomm.shipping.delete({ site_name: site_name, id: id });
 ```
 
+# eComm Shipping Zones
+
+## List Shipping Zones
+
+[List Shipping Zones Reference](https://developer.duda.co/reference/ecommerce-list-shipping-zones)
+
+### Request
+
+`GET https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones`
+
+```typescript
+duda.ecomm.shipping_zones.list({ site_name: site_name });
+```
+
+## Get Shipping Zone
+
+[Get Shipping Zone Reference](https://developer.duda.co/reference/ecommerce-get-shipping-zone)
+
+### Request
+
+`GET https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones/{id}`
+
+```typescript
+duda.ecomm.shipping_zones.get({ site_name: site_name, id: id });
+```
+
+## Update Shipping Zone
+
+[Update Shipping Zone Reference](https://developer.duda.co/reference/ecommerce-update-shipping-zone)
+
+### Request
+
+`PATCH https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones/{id}`
+
+```typescript
+duda.ecomm.shipping_zones.update({ site_name: site_name, id: id });
+```
+
+## Delete Shipping Zone
+
+[Delete Shipping Zone Reference](https://developer.duda.co/reference/ecommerce-delete-shipping-zone)
+
+### Request
+
+`DELETE https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones/{id}`
+
+```typescript
+duda.ecomm.shipping_zones.delete({ site_name: site_name, id: id });
+```
+
+## List Shipping Zone Methods
+
+[List Shipping Zone Methods Reference](https://developer.duda.co/reference/ecommerce-list-shipping-zone-methods)
+
+### Request
+
+`GET https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods`
+
+```typescript
+duda.ecomm.shipping_zones.listMethod({ site_name: site_name, zone_id: zone_id });
+```
+
+## Get Shipping Zone Method
+
+[Get Shipping Zone Method Reference](https://developer.duda.co/reference/ecommerce-get-shipping-zone-method)
+
+### Request
+
+`GET https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods/{id}`
+
+```typescript
+duda.ecomm.shipping_zones.getMethod({ site_name: site_name, zone_id: zone_id, id: id });
+```
+
+## Create Shipping Zone Method
+
+[Create Shipping Zone Method Reference](https://developer.duda.co/reference/ecommerce-create-shipping-zone-method)
+
+### Request
+
+`POST https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods`
+
+```typescript
+duda.ecomm.shipping_zones.createMethod({ site_name: site_name, zone_id: zone_id, type: type, name: name, rates: rates });
+```
+
+## Update Shipping Zone Method
+
+[Update Shipping Zone Method Reference](https://developer.duda.co/reference/ecommerce-update-shipping-zone-method)
+
+### Request
+
+`PATCH https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods/{id}`
+
+```typescript
+duda.ecomm.shipping_zones.updateMethod({ site_name: site_name, zone_id: zone_id, id: id });
+```
+
+## Delete Shipping Zone Method
+
+[Delete Shipping Zone Method Reference](https://developer.duda.co/reference/ecommerce-delete-shipping-zone-method)
+
+### Request
+
+`DELETE https://api.duda.co/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods/{id}`
+
+```typescript
+duda.ecomm.shipping_zones.deleteMethod({ site_name: site_name, zone_id: zone_id, id: id });
+```
+
 # eComm Products
 
 ## List Products

--- a/README.md
+++ b/README.md
@@ -4487,6 +4487,116 @@ duda.appstore.ecomm.shipping.update({ site_name: site_name, id: id });
 duda.appstore.ecomm.shipping.delete({ site_name: site_name, id: id });
 ```
 
+# Appstore eComm Shipping Zones
+
+## List Shipping Zones
+
+[List Shipping Zones Reference](https://developer.duda.co/reference/app-ecommerce-list-shipping-zones)
+
+### Request
+
+`GET https://api.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/shipping-zones`
+
+```typescript
+duda.appstore.ecomm.shipping_zones.list({ site_name: site_name });
+```
+
+## Get Shipping Zone
+
+[Get Shipping Zone Reference](https://developer.duda.co/reference/app-ecommerce-get-shipping-zone)
+
+### Request
+
+`GET https://api.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/shipping-zones/{id}`
+
+```typescript
+duda.appstore.ecomm.shipping_zones.get({ site_name: site_name, id: id });
+```
+
+## Update Shipping Zone
+
+[Update Shipping Zone Reference](https://developer.duda.co/reference/app-ecommerce-update-shipping-zone)
+
+### Request
+
+`PATCH https://api.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/shipping-zones/{id}`
+
+```typescript
+duda.appstore.ecomm.shipping_zones.update({ site_name: site_name, id: id });
+```
+
+## Delete Shipping Zone
+
+[Delete Shipping Zone Reference](https://developer.duda.co/reference/app-ecommerce-delete-shipping-zone)
+
+### Request
+
+`DELETE https://api.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/shipping-zones/{id}`
+
+```typescript
+duda.appstore.ecomm.shipping_zones.delete({ site_name: site_name, id: id });
+```
+
+## List Shipping Zone Methods
+
+[List Shipping Zone Methods Reference](https://developer.duda.co/reference/app-ecommerce-list-shipping-zone-methods)
+
+### Request
+
+`GET https://api.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods`
+
+```typescript
+duda.appstore.ecomm.shipping_zones.listMethod({ site_name: site_name, zone_id: zone_id });
+```
+
+## Get Shipping Zone Method
+
+[Get Shipping Zone Method Reference](https://developer.duda.co/reference/app-ecommerce-get-shipping-zone-method)
+
+### Request
+
+`GET https://api.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods/{id}`
+
+```typescript
+duda.appstore.ecomm.shipping_zones.getMethod({ site_name: site_name, zone_id: zone_id, id: id });
+```
+
+## Create Shipping Zone Method
+
+[Create Shipping Zone Method Reference](https://developer.duda.co/reference/app-ecommerce-create-shipping-zone-method)
+
+### Request
+
+`POST https://api.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods`
+
+```typescript
+duda.appstore.ecomm.shipping_zones.createMethod({ site_name: site_name, zone_id: zone_id, type: type, name: name, rates: rates });
+```
+
+## Update Shipping Zone Method
+
+[Update Shipping Zone Method Reference](https://developer.duda.co/reference/app-ecommerce-update-shipping-zone-method)
+
+### Request
+
+`PATCH https://api.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods/{id}`
+
+```typescript
+duda.appstore.ecomm.shipping_zones.updateMethod({ site_name: site_name, zone_id: zone_id, id: id });
+```
+
+## Delete Shipping Zone Method
+
+[Delete Shipping Zone Method Reference](https://developer.duda.co/reference/app-ecommerce-delete-shipping-zone-method)
+
+### Request
+
+`DELETE https://api.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods/{id}`
+
+```typescript
+duda.appstore.ecomm.shipping_zones.deleteMethod({ site_name: site_name, zone_id: zone_id, id: id });
+```
+
 # Appstore eComm Store
 
 ## Get Store

--- a/src/lib/apps/ecomm/Ecomm.ts
+++ b/src/lib/apps/ecomm/Ecomm.ts
@@ -9,6 +9,7 @@ import AppsGateways from './Gateways';
 import AppsCarts from './Carts';
 import AppsVariations from './Variations';
 import AppsShipping from './Shipping';
+import AppsShippingZones from './Shipping_Zones';
 import AppsStore from './Store';
 import AppsRefundIntent from './RefundIntent';
 import { TokenRequest } from '../types';
@@ -29,6 +30,8 @@ class AppsEcomm extends SubResource {
   variations = new AppsVariations(this.base);
 
   shipping = new AppsShipping(this.base);
+
+  shipping_zones = new AppsShippingZones(this.base);
 
   store = new AppsStore(this.base);
 

--- a/src/lib/apps/ecomm/Shipping_Zones.ts
+++ b/src/lib/apps/ecomm/Shipping_Zones.ts
@@ -1,0 +1,162 @@
+import * as Types from './types';
+import { SubResource } from '../../base';
+import { APIEndpoint } from '../../APIEndpoint';
+import { TokenRequest } from '../types';
+
+class AppsShippingZones extends SubResource {
+  list = APIEndpoint<TokenRequest<Types.ListShippingZonesPayload>, Types.ListShippingZonesResponse>({
+    method: 'get',
+    path: '/site/{site_name}/ecommerce/shipping-zones',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+    queryParams: {
+      offset: {
+        type: 'number',
+        required: false,
+      },
+      limit: {
+        type: 'number',
+        required: false,
+      },
+      sort: {
+        type: 'string',
+        required: false,
+      },
+      direction: {
+        type: 'string',
+        required: false,
+      },
+    },
+  });
+
+  get = APIEndpoint<TokenRequest<Types.GetShippingZonePayload>, Types.GetShippingZoneResponse>({
+    method: 'get',
+    path: '/site/{site_name}/ecommerce/shipping-zones/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  update = APIEndpoint<TokenRequest<Types.UpdateShippingZonePayload>, Types.UpdateShippingZoneResponse>({
+    method: 'patch',
+    path: '/site/{site_name}/ecommerce/shipping-zones/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  delete = APIEndpoint<TokenRequest<Types.DeleteShippingZonePayload>, Types.DeleteShippingZoneResponse>({
+    method: 'delete',
+    path: '/site/{site_name}/ecommerce/shipping-zones/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  listMethod = APIEndpoint<TokenRequest<Types.ListShippingZoneMethodsPayload>, Types.ListShippingZoneMethodsResponse>({
+    method: 'get',
+    path: '/site/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+    queryParams: {
+      offset: {
+        type: 'number',
+        required: false,
+      },
+      limit: {
+        type: 'number',
+        required: false,
+      },
+      sort: {
+        type: 'string',
+        required: false,
+      },
+      direction: {
+        type: 'string',
+        required: false,
+      },
+    },
+  });
+
+  getMethod = APIEndpoint<TokenRequest<Types.GetShippingZoneMethodPayload>, Types.GetShippingZoneMethodResponse>({
+    method: 'get',
+    path: '/site/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  createMethod = APIEndpoint<TokenRequest<Types.CreateShippingZoneMethodPayload>, Types.CreateShippingZoneMethodResponse>({
+    method: 'post',
+    path: '/site/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  updateMethod = APIEndpoint<TokenRequest<Types.UpdateShippingZoneMethodPayload>, Types.UpdateShippingZoneMethodResponse>({
+    method: 'patch',
+    path: '/site/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+
+  deleteMethod = APIEndpoint<TokenRequest<Types.DeleteShippingZoneMethodPayload>, Types.DeleteShippingZoneMethodResponse>({
+    method: 'delete',
+    path: '/site/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    headerOptions: {
+      'X-DUDA-ACCESS-TOKEN': {
+        required: true,
+      },
+    },
+  });
+}
+
+export default AppsShippingZones;
+export { AppsShippingZones };

--- a/src/lib/ecomm/Ecomm.ts
+++ b/src/lib/ecomm/Ecomm.ts
@@ -8,6 +8,7 @@ import Payments from './Payments';
 import Categories from './Categories';
 import ProductCategories from './Product_Categories';
 import Shipping from './Shipping';
+import ShippingZones from './Shipping_Zones';
 import Products from './Products';
 import Options from './Options';
 import Variations from './Variations';
@@ -35,6 +36,8 @@ class Ecomm extends Resource {
   product_categories = new ProductCategories(this.config);
 
   shipping = new Shipping(this.config);
+
+  shipping_zones = new ShippingZones(this.config);
 
   products = new Products(this.config);
 

--- a/src/lib/ecomm/Shipping_Zones.ts
+++ b/src/lib/ecomm/Shipping_Zones.ts
@@ -1,0 +1,116 @@
+import * as Types from './types';
+import Resource from '../base';
+import { APIEndpoint } from '../APIEndpoint';
+
+class ShippingZones extends Resource {
+  list = APIEndpoint<Types.ListShippingZonesPayload, Types.ListShippingZonesResponse>({
+    method: 'get',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    queryParams: {
+      offset: {
+        type: 'number',
+        required: false,
+      },
+      limit: {
+        type: 'number',
+        required: false,
+      },
+      sort: {
+        type: 'string',
+        required: false,
+      },
+      direction: {
+        type: 'string',
+        required: false,
+      },
+    },
+  });
+
+  get = APIEndpoint<Types.GetShippingZonePayload, Types.GetShippingZoneResponse>({
+    method: 'get',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  update = APIEndpoint<Types.UpdateShippingZonePayload, Types.UpdateShippingZoneResponse>({
+    method: 'patch',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  delete = APIEndpoint<Types.DeleteShippingZonePayload, Types.DeleteShippingZoneResponse>({
+    method: 'delete',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  listMethod = APIEndpoint<Types.ListShippingZoneMethodsPayload, Types.ListShippingZoneMethodsResponse>({
+    method: 'get',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods',
+    defaults: {
+      host: 'api.duda.co',
+    },
+    queryParams: {
+      offset: {
+        type: 'number',
+        required: false,
+      },
+      limit: {
+        type: 'number',
+        required: false,
+      },
+      sort: {
+        type: 'string',
+        required: false,
+      },
+      direction: {
+        type: 'string',
+        required: false,
+      },
+    },
+  });
+
+  getMethod = APIEndpoint<Types.GetShippingZoneMethodPayload, Types.GetShippingZoneMethodResponse>({
+    method: 'get',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  createMethod = APIEndpoint<Types.CreateShippingZoneMethodPayload, Types.CreateShippingZoneMethodResponse>({
+    method: 'post',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  updateMethod = APIEndpoint<Types.UpdateShippingZoneMethodPayload, Types.UpdateShippingZoneMethodResponse>({
+    method: 'patch',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+
+  deleteMethod = APIEndpoint<Types.DeleteShippingZoneMethodPayload, Types.DeleteShippingZoneMethodResponse>({
+    method: 'delete',
+    path: '/api/sites/multiscreen/{site_name}/ecommerce/shipping-zones/{zone_id}/shipping-methods/{id}',
+    defaults: {
+      host: 'api.duda.co',
+    },
+  });
+}
+
+export default ShippingZones;
+export { ShippingZones };

--- a/src/lib/ecomm/types.ts
+++ b/src/lib/ecomm/types.ts
@@ -1023,6 +1023,137 @@ export interface DeleteProductCategoriesPayload {
 
 export type DeleteProductCategoriesResponse = null;
 
+interface ShippingZoneLocation {
+  country: string,
+  region?: string
+}
+
+type ShippingMethodType =
+  'FREE' |
+  'FLAT_RATE' |
+  'CART_PRICE_BASED' |
+  'CART_WEIGHT_BASED' |
+  'UNKNOWN' |
+  string;
+
+interface ShippingMethodRate {
+  price: number,
+  min_cart_weight?: number,
+  max_cart_weight?: number,
+  min_cart_value?: number,
+  max_cart_value?: number
+}
+
+interface ShippingZoneMethodPayload {
+  type: ShippingMethodType,
+  name: string,
+  min_delivery_time_in_days?: number,
+  max_delivery_time_in_days?: number,
+  rates: Array<ShippingMethodRate>
+}
+
+interface ShippingZoneMethod extends ShippingZoneMethodPayload {
+  id: string
+}
+
+interface ShippingZone {
+  id: string,
+  name: string,
+  locations?: Array<ShippingZoneLocation>,
+  postal_codes?: Array<string>,
+  has_automated_shipping?: boolean,
+  shipping_methods?: Array<ShippingZoneMethod>
+}
+
+export interface ListShippingZonesPayload {
+  site_name: string,
+  offset?: number,
+  limit?: number,
+  sort?: string,
+  direction?: string
+}
+
+export interface ListShippingZonesResponse {
+  offset: number,
+  limit: number,
+  total_responses: number,
+  results: Array<ShippingZone>
+}
+
+export interface GetShippingZonePayload {
+  site_name: string,
+  id: string
+}
+
+export interface GetShippingZoneResponse extends ShippingZone {}
+
+export interface UpdateShippingZonePayload {
+  site_name: string,
+  id: string,
+  name?: string,
+  locations?: Array<ShippingZoneLocation>,
+  postal_codes?: Array<string>,
+  has_automated_shipping?: boolean,
+  shipping_methods?: Array<ShippingZoneMethodPayload>
+}
+
+export interface UpdateShippingZoneResponse extends ShippingZone {}
+
+export interface DeleteShippingZonePayload {
+  site_name: string,
+  id: string
+}
+
+export type DeleteShippingZoneResponse = null;
+
+export interface ListShippingZoneMethodsPayload {
+  site_name: string,
+  zone_id: string,
+  offset?: number,
+  limit?: number,
+  sort?: string,
+  direction?: string
+}
+
+export interface ListShippingZoneMethodsResponse {
+  offset: number,
+  limit: number,
+  total_responses: number,
+  results: Array<ShippingZoneMethod>
+}
+
+export interface GetShippingZoneMethodPayload {
+  site_name: string,
+  zone_id: string,
+  id: string
+}
+
+export interface GetShippingZoneMethodResponse extends ShippingZoneMethod {}
+
+export interface CreateShippingZoneMethodPayload extends ShippingZoneMethodPayload {
+  site_name: string,
+  zone_id: string
+}
+
+export interface CreateShippingZoneMethodResponse extends ShippingZoneMethod {}
+
+export interface UpdateShippingZoneMethodPayload {
+  site_name: string,
+  zone_id: string,
+  id: string,
+  type?: ShippingMethodType,
+  name?: string,
+  min_delivery_time_in_days?: number,
+  max_delivery_time_in_days?: number,
+  rates?: Array<ShippingMethodRate>
+}
+
+export interface UpdateShippingZoneMethodResponse extends ShippingZoneMethod {}
+
+export interface DeleteShippingZoneMethodPayload extends GetShippingZoneMethodPayload {}
+
+export type DeleteShippingZoneMethodResponse = null;
+
 export interface ShippingProvider {
   id: string,
   live_shipping_rates_url: string,

--- a/tests/app/ecomm.tests.ts
+++ b/tests/app/ecomm.tests.ts
@@ -17,6 +17,57 @@ describe('App store ecomm tests', () => {
   const cart_id = 'test_cart';
   const variation_id = 'test_variation';
   const shipping_id = 'test_shipping';
+  const shipping_zone_id = 'sz_test';
+  const shipping_method_id = 'sm_test';
+
+  const shipping_zone_method_payload = {
+    type: 'FLAT_RATE',
+    name: 'string',
+    min_delivery_time_in_days: 1,
+    max_delivery_time_in_days: 2,
+    rates: [
+      {
+        price: 10,
+        min_cart_weight: 0,
+        max_cart_weight: 1000,
+        min_cart_value: 0,
+        max_cart_value: 100
+      }
+    ]
+  }
+
+  const shipping_zone_method = {
+    id: shipping_method_id,
+    ...shipping_zone_method_payload
+  }
+
+  const shipping_zone = {
+    id: shipping_zone_id,
+    name: 'string',
+    locations: [
+      {
+        country: 'US',
+        region: 'US-CO'
+      }
+    ],
+    postal_codes: ['80027'],
+    has_automated_shipping: false,
+    shipping_methods: [shipping_zone_method]
+  }
+
+  const list_shipping_zones_response = {
+    offset: 0,
+    limit: 1,
+    total_responses: 1,
+    results: [shipping_zone]
+  }
+
+  const list_shipping_zone_methods_response = {
+    offset: 0,
+    limit: 1,
+    total_responses: 1,
+    results: [shipping_zone_method]
+  }
 
   const offset = 0;
   const sort = 'sort';
@@ -1239,6 +1290,107 @@ describe('App store ecomm tests', () => {
   it('can delete a shipping provider', async () => {
     scope.delete(`${base_path}/site/${site_name}/ecommerce/shipping-providers/${shipping_id}`).reply(204)
     return await duda.appstore.ecomm.shipping.delete({ site_name, id: shipping_id, token })
+  })
+
+  it('can list shipping zones', async () => {
+    scope.get(`${base_path}/site/${site_name}/ecommerce/shipping-zones?offset=0&limit=1&sort=name&direction=asc`).reply(200, list_shipping_zones_response)
+    return await duda.appstore.ecomm.shipping_zones.list({
+      site_name,
+      offset: 0,
+      limit: 1,
+      sort: 'name',
+      direction: 'asc',
+      token
+    }).then(res => expect(res).to.eql(list_shipping_zones_response))
+  })
+
+  it('can get a shipping zone', async () => {
+    scope.get(`${base_path}/site/${site_name}/ecommerce/shipping-zones/${shipping_zone_id}`).reply(200, shipping_zone)
+    return await duda.appstore.ecomm.shipping_zones.get({ site_name, id: shipping_zone_id, token })
+      .then(res => expect(res).to.eql(shipping_zone))
+  })
+
+  it('can update a shipping zone', async () => {
+    scope.patch(`${base_path}/site/${site_name}/ecommerce/shipping-zones/${shipping_zone_id}`, (body) => {
+      expect(body).to.eql({
+        name: 'string',
+        locations: [
+          {
+            country: 'US',
+            region: 'US-CO'
+          }
+        ],
+        postal_codes: ['80027'],
+        has_automated_shipping: false,
+        shipping_methods: [shipping_zone_method_payload]
+      })
+      return body
+    }).reply(200, shipping_zone)
+
+    return await duda.appstore.ecomm.shipping_zones.update({
+      site_name,
+      id: shipping_zone_id,
+      name: 'string',
+      locations: [
+        {
+          country: 'US',
+          region: 'US-CO'
+        }
+      ],
+      postal_codes: ['80027'],
+      has_automated_shipping: false,
+      shipping_methods: [shipping_zone_method_payload],
+      token
+    }).then(res => expect(res).to.eql(shipping_zone))
+  })
+
+  it('can delete a shipping zone', async () => {
+    scope.delete(`${base_path}/site/${site_name}/ecommerce/shipping-zones/${shipping_zone_id}`).reply(204)
+    return await duda.appstore.ecomm.shipping_zones.delete({ site_name, id: shipping_zone_id, token })
+  })
+
+  it('can list shipping zone methods', async () => {
+    scope.get(`${base_path}/site/${site_name}/ecommerce/shipping-zones/${shipping_zone_id}/shipping-methods?offset=0&limit=1&sort=name&direction=asc`).reply(200, list_shipping_zone_methods_response)
+    return await duda.appstore.ecomm.shipping_zones.listMethod({
+      site_name,
+      zone_id: shipping_zone_id,
+      offset: 0,
+      limit: 1,
+      sort: 'name',
+      direction: 'asc',
+      token
+    }).then(res => expect(res).to.eql(list_shipping_zone_methods_response))
+  })
+
+  it('can get a shipping zone method', async () => {
+    scope.get(`${base_path}/site/${site_name}/ecommerce/shipping-zones/${shipping_zone_id}/shipping-methods/${shipping_method_id}`).reply(200, shipping_zone_method)
+    return await duda.appstore.ecomm.shipping_zones.getMethod({ site_name, zone_id: shipping_zone_id, id: shipping_method_id, token })
+      .then(res => expect(res).to.eql(shipping_zone_method))
+  })
+
+  it('can create a shipping zone method', async () => {
+    scope.post(`${base_path}/site/${site_name}/ecommerce/shipping-zones/${shipping_zone_id}/shipping-methods`, (body) => {
+      expect(body).to.eql({ ...shipping_zone_method_payload })
+      return body
+    }).reply(201, shipping_zone_method)
+
+    return await duda.appstore.ecomm.shipping_zones.createMethod({ site_name, zone_id: shipping_zone_id, token, ...shipping_zone_method_payload })
+      .then(res => expect(res).to.eql(shipping_zone_method))
+  })
+
+  it('can update a shipping zone method', async () => {
+    scope.patch(`${base_path}/site/${site_name}/ecommerce/shipping-zones/${shipping_zone_id}/shipping-methods/${shipping_method_id}`, (body) => {
+      expect(body).to.eql({ ...shipping_zone_method_payload })
+      return body
+    }).reply(200, shipping_zone_method)
+
+    return await duda.appstore.ecomm.shipping_zones.updateMethod({ site_name, zone_id: shipping_zone_id, id: shipping_method_id, token, ...shipping_zone_method_payload })
+      .then(res => expect(res).to.eql(shipping_zone_method))
+  })
+
+  it('can delete a shipping zone method', async () => {
+    scope.delete(`${base_path}/site/${site_name}/ecommerce/shipping-zones/${shipping_zone_id}/shipping-methods/${shipping_method_id}`).reply(204)
+    return await duda.appstore.ecomm.shipping_zones.deleteMethod({ site_name, zone_id: shipping_zone_id, id: shipping_method_id, token })
   })
 
   it('can create a gateway', async () => {

--- a/tests/ecomm.tests.ts
+++ b/tests/ecomm.tests.ts
@@ -1065,6 +1065,58 @@ describe('Ecomm tests', () => {
     next_page: "string"
   }
 
+  const shipping_zone_id = 'sz_test'
+  const shipping_method_id = 'sm_test'
+
+  const shipping_zone_method_payload = {
+    type: 'FLAT_RATE',
+    name: 'string',
+    min_delivery_time_in_days: 1,
+    max_delivery_time_in_days: 2,
+    rates: [
+      {
+        price: 10,
+        min_cart_weight: 0,
+        max_cart_weight: 1000,
+        min_cart_value: 0,
+        max_cart_value: 100
+      }
+    ]
+  }
+
+  const shipping_zone_method = {
+    id: shipping_method_id,
+    ...shipping_zone_method_payload
+  }
+
+  const shipping_zone = {
+    id: shipping_zone_id,
+    name: 'string',
+    locations: [
+      {
+        country: 'US',
+        region: 'US-CO'
+      }
+    ],
+    postal_codes: ['80027'],
+    has_automated_shipping: false,
+    shipping_methods: [shipping_zone_method]
+  }
+
+  const list_shipping_zones_response = {
+    offset: 0,
+    limit: 1,
+    total_responses: 1,
+    results: [shipping_zone]
+  }
+
+  const list_shipping_zone_methods_response = {
+    offset: 0,
+    limit: 1,
+    total_responses: 1,
+    results: [shipping_zone_method]
+  }
+
   const bulk_update_category_payload = {
     categories: [
       {
@@ -1715,6 +1767,104 @@ describe('Ecomm tests', () => {
     }).reply(204)
 
     return await duda.ecomm.product_categories.delete({ site_name, ...product_categories_relations_payload })
+  })
+
+  it('can list shipping zones', async () => {
+    scope.get(`/api/sites/multiscreen/${site_name}/ecommerce/shipping-zones?offset=0&limit=1&sort=name&direction=asc`).reply(200, list_shipping_zones_response)
+    return await duda.ecomm.shipping_zones.list({
+      site_name,
+      offset: 0,
+      limit: 1,
+      sort: 'name',
+      direction: 'asc'
+    }).then(res => expect(res).to.eql(list_shipping_zones_response))
+  })
+
+  it('can get a shipping zone', async () => {
+    scope.get(`/api/sites/multiscreen/${site_name}/ecommerce/shipping-zones/${shipping_zone_id}`).reply(200, shipping_zone)
+    return await duda.ecomm.shipping_zones.get({ site_name, id: shipping_zone_id })
+      .then(res => expect(res).to.eql(shipping_zone))
+  })
+
+  it('can update a shipping zone', async () => {
+    scope.patch(`/api/sites/multiscreen/${site_name}/ecommerce/shipping-zones/${shipping_zone_id}`, (body) => {
+      expect(body).to.eql({
+        name: 'string',
+        locations: [
+          {
+            country: 'US',
+            region: 'US-CO'
+          }
+        ],
+        postal_codes: ['80027'],
+        has_automated_shipping: false,
+        shipping_methods: [shipping_zone_method_payload]
+      })
+      return body
+    }).reply(200, shipping_zone)
+
+    return await duda.ecomm.shipping_zones.update({
+      site_name,
+      id: shipping_zone_id,
+      name: 'string',
+      locations: [
+        {
+          country: 'US',
+          region: 'US-CO'
+        }
+      ],
+      postal_codes: ['80027'],
+      has_automated_shipping: false,
+      shipping_methods: [shipping_zone_method_payload]
+    }).then(res => expect(res).to.eql(shipping_zone))
+  })
+
+  it('can delete a shipping zone', async () => {
+    scope.delete(`/api/sites/multiscreen/${site_name}/ecommerce/shipping-zones/${shipping_zone_id}`).reply(204)
+    return await duda.ecomm.shipping_zones.delete({ site_name, id: shipping_zone_id })
+  })
+
+  it('can list shipping zone methods', async () => {
+    scope.get(`/api/sites/multiscreen/${site_name}/ecommerce/shipping-zones/${shipping_zone_id}/shipping-methods?offset=0&limit=1&sort=name&direction=asc`).reply(200, list_shipping_zone_methods_response)
+    return await duda.ecomm.shipping_zones.listMethod({
+      site_name,
+      zone_id: shipping_zone_id,
+      offset: 0,
+      limit: 1,
+      sort: 'name',
+      direction: 'asc'
+    }).then(res => expect(res).to.eql(list_shipping_zone_methods_response))
+  })
+
+  it('can get a shipping zone method', async () => {
+    scope.get(`/api/sites/multiscreen/${site_name}/ecommerce/shipping-zones/${shipping_zone_id}/shipping-methods/${shipping_method_id}`).reply(200, shipping_zone_method)
+    return await duda.ecomm.shipping_zones.getMethod({ site_name, zone_id: shipping_zone_id, id: shipping_method_id })
+      .then(res => expect(res).to.eql(shipping_zone_method))
+  })
+
+  it('can create a shipping zone method', async () => {
+    scope.post(`/api/sites/multiscreen/${site_name}/ecommerce/shipping-zones/${shipping_zone_id}/shipping-methods`, (body) => {
+      expect(body).to.eql({ ...shipping_zone_method_payload })
+      return body
+    }).reply(201, shipping_zone_method)
+
+    return await duda.ecomm.shipping_zones.createMethod({ site_name, zone_id: shipping_zone_id, ...shipping_zone_method_payload })
+      .then(res => expect(res).to.eql(shipping_zone_method))
+  })
+
+  it('can update a shipping zone method', async () => {
+    scope.patch(`/api/sites/multiscreen/${site_name}/ecommerce/shipping-zones/${shipping_zone_id}/shipping-methods/${shipping_method_id}`, (body) => {
+      expect(body).to.eql({ ...shipping_zone_method_payload })
+      return body
+    }).reply(200, shipping_zone_method)
+
+    return await duda.ecomm.shipping_zones.updateMethod({ site_name, zone_id: shipping_zone_id, id: shipping_method_id, ...shipping_zone_method_payload })
+      .then(res => expect(res).to.eql(shipping_zone_method))
+  })
+
+  it('can delete a shipping zone method', async () => {
+    scope.delete(`/api/sites/multiscreen/${site_name}/ecommerce/shipping-zones/${shipping_zone_id}/shipping-methods/${shipping_method_id}`).reply(204)
+    return await duda.ecomm.shipping_zones.deleteMethod({ site_name, zone_id: shipping_zone_id, id: shipping_method_id })
   })
 
   it('can list all shipping providers', async () => {


### PR DESCRIPTION
## Summary

Adds the native-store shipping zones API to both SDK surfaces: `duda.ecomm.shipping_zones` and `duda.appstore.ecomm.shipping_zones`.

## Changes

Nine operations each (zones have no create — matching the published API):

| SDK call | Endpoint |
|---|---|
| `list` / `get` / `update` / `delete` | `.../ecommerce/shipping-zones[/{id}]` |
| `listMethod` / `getMethod` / `createMethod` / `updateMethod` / `deleteMethod` | `.../shipping-zones/{zone_id}/shipping-methods[/{id}]` |

- Types: `ShippingZone` (locations, postal codes, Easyship flag), `ShippingZoneMethod` with type enum (FREE/FLAT_RATE/CART_PRICE_BASED/CART_WEIGHT_BASED/UNKNOWN) and rate windows
- 18 tests (9 direct + 9 appstore, token header asserted); README sections for both surfaces

## Stack

Merge bottom-up into `release/3.4.0`:

1. Blog Posts Content Query Param (`feat/blog-posts-content-param`)
2. App Store Blog Endpoints (`feat/blogs-appstore`)
3. Async Tasks: Generate Site with AI v2 (`feat/async-site-tasks`)
4. Team Permissions Fixes (`chore/permissions-object`)
5. eComm Product Categories Endpoints (`feat/product-categories`)
6. eComm Shipping Zones Endpoints (`feat/shipping-zones-endpoints`)
7. eComm Carts Fixes (`fix/cart-api`)
