### PR TITLE
eComm Carts Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4631,7 +4631,7 @@ duda.appstore.ecomm.carts.list({ site_name: site_name });
 
 ### Request
 
-`GET get https://api-sandbox.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/carts/{cart_id}`
+`GET https://api-sandbox.duda.co/api/integrationhub/application/site/{site_name}/ecommerce/carts/{cart_id}`
 
 ```typescript
 duda.appstore.ecomm.carts.get({ site_name: site_name, cart_id: cart_id });

--- a/src/lib/apps/ecomm/Carts.ts
+++ b/src/lib/apps/ecomm/Carts.ts
@@ -24,10 +24,6 @@ class AppsCarts extends SubResource {
         type: 'string',
         required: false,
       },
-      email: {
-        type: 'string',
-        required: false,
-      },
       cursor: {
         type: 'string',
         required: false,

--- a/src/lib/ecomm/Carts.ts
+++ b/src/lib/ecomm/Carts.ts
@@ -18,10 +18,6 @@ class Carts extends Resource {
         type: 'string',
         required: false,
       },
-      email: {
-        type: 'string',
-        required: false,
-      },
       cursor: {
         type: 'string',
         required: false,

--- a/src/lib/ecomm/types.ts
+++ b/src/lib/ecomm/types.ts
@@ -274,6 +274,7 @@ export interface CartItem {
   external_product_id: string,
   external_variation_id: string,
   name: string,
+  sku: string,
   image: string,
   options: {
     name: string,

--- a/src/lib/ecomm/types.ts
+++ b/src/lib/ecomm/types.ts
@@ -364,7 +364,6 @@ export interface ListCartsPayload {
   site_name: string,
   status?: 'IN_PROGRESS' | 'ABANDONED',
   mode?: 'LIVE' | 'TEST',
-  email?: string,
   cursor?: string,
   limit?: number
 }

--- a/tests/app/ecomm.tests.ts
+++ b/tests/app/ecomm.tests.ts
@@ -722,6 +722,7 @@ describe('App store ecomm tests', () => {
         external_product_id: "string",
         external_variation_id: "string",
         name: "string",
+        sku: "string",
         image: "string",
         options: [
           {

--- a/tests/ecomm.tests.ts
+++ b/tests/ecomm.tests.ts
@@ -427,6 +427,7 @@ describe('Ecomm tests', () => {
         external_product_id: "string",
         external_variation_id: "string",
         name: "string",
+        sku: "string",
         image: "string",
         options: [
           {


### PR DESCRIPTION
## Summary

Aligns the existing carts endpoints with the current backend contract.

## Changes

- Removed the `email` query param from both list-carts endpoints and `ListCartsPayload` — the API never supported it (docs confirm email is response-only)
- Added `sku` to `CartItem` — the backend CartOutputDto now includes it on items (also sent to external shipping providers)
- Cart fixtures updated with `sku`; fixed a `GET get` method typo in the appstore Get Cart README entry

## Stack

Merge bottom-up into `release/3.4.0`:

1. Blog Posts Content Query Param (`feat/blog-posts-content-param`)
2. App Store Blog Endpoints (`feat/blogs-appstore`)
3. Async Tasks: Generate Site with AI v2 (`feat/async-site-tasks`)
4. Team Permissions Fixes (`chore/permissions-object`)
5. eComm Product Categories Endpoints (`feat/product-categories`)
6. eComm Shipping Zones Endpoints (`feat/shipping-zones-endpoints`)
7. eComm Carts Fixes (`fix/cart-api`)
